### PR TITLE
feat: OAuth 2.1 authorization + four new dashboard tools

### DIFF
--- a/juspay_dashboard_mcp/api/account.py
+++ b/juspay_dashboard_mcp/api/account.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+
+import logging
+import os
+
+import httpx
+
+from juspay_dashboard_mcp.api.utils import get_juspay_credentials
+from juspay_dashboard_mcp.config import JUSPAY_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+# Portal requires this byte-exact resource query string (literal `{` `}` and
+# `%20` for spaces) — same form used by the OAuth validation path.
+_AUTHORIZE_QUERY = "resource={%22COMMON%22%20%3A%20%22R%22}"
+
+
+async def get_merchant_details_juspay(payload: dict = None, meta_info: dict = None) -> dict:
+    """Return merchant + user session details for the authenticated caller.
+
+    Calls Portal's authorize endpoint and surfaces the full response so the
+    LLM gets merchantId, userId, email, context (MERCHANT/TENANT/RESELLER/
+    JUSPAY), username, tenantAccountId, validHost, and any other fields
+    Portal exposes for the current session.
+    """
+    juspay_creds = get_juspay_credentials()
+    token = juspay_creds.get("dashboard_token") if juspay_creds else None
+    if not token and meta_info:
+        token = meta_info.get("x-web-logintoken")
+    if not token:
+        token = os.environ.get("JUSPAY_WEB_LOGIN_TOKEN")
+    if not token:
+        raise Exception("Juspay token not provided.")
+
+    url = f"{JUSPAY_BASE_URL}/ec/v2/authorize?{_AUTHORIZE_QUERY}"
+    headers = {"Authorization": token}
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        logger.info(f"GET {url}")
+        resp = await client.get(url, headers=headers)
+        resp.raise_for_status()
+        return resp.json()

--- a/juspay_dashboard_mcp/api/api_keys.py
+++ b/juspay_dashboard_mcp/api/api_keys.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+
+from juspay_dashboard_mcp.api.utils import post, get_juspay_host_from_api
+
+
+async def create_api_key_juspay(payload: dict, meta_info: dict = None) -> dict:
+    """Generate a new API key for the authenticated merchant.
+
+    Accepts a `description` label that identifies the key in the merchant's
+    API Keys listing. Returns the full creation response including the
+    plaintext `apiKey` (shown only at creation), `maskedApiKey`, `id`,
+    `status`, `scope`, `dateCreated`, `lastUpdated`, `merchantAccountId`,
+    `version`, and `metadata`.
+    """
+    host = await get_juspay_host_from_api(meta_info=meta_info)
+    request_payload = {"description": payload["description"]}
+    api_url = f"{host}/api/ec/v1/apiKeys"
+    return await post(api_url, request_payload, None, meta_info)

--- a/juspay_dashboard_mcp/api/integrationChecklist.py
+++ b/juspay_dashboard_mcp/api/integrationChecklist.py
@@ -1,0 +1,184 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+import os
+import dotenv
+from juspay_dashboard_mcp.api.utils import post, get_juspay_host_from_api
+
+dotenv.load_dotenv()
+
+JUSPAY_ENV = os.getenv("JUSPAY_ENV", "production").lower() 
+integrationSuffix = "ic-api" if JUSPAY_ENV == "production" else "ic"
+    
+async def get_integration_monitoring_status_juspay(payload: dict, meta_info: dict = None) -> dict:
+    """
+    Retrieves integration monitoring status for specified platform and product.
+    
+    Automatically routes to:
+    - agnostic API for Backend platform (excludes platform from request)
+    - nonagnostic API for Web/Android/iOS platforms (includes platform in request)
+    
+    Args:
+        payload (dict): Contains platform, product_integrated, merchant_id, start_time, end_time
+        meta_info (dict): Optional metadata
+        
+    Returns:
+        dict: Integration monitoring status data
+    """
+    platform = payload.get("platform")
+    
+    api_payload_obj = {
+        "timeRange": {
+            "startTime": payload["start_time"],
+            "endTime": payload["end_time"]
+        },
+        "groupByNames": ["stage"],
+        "filters": {
+            "merchant_id": [payload["merchant_id"]],
+            "product_integrated": [payload["product_integrated"]]
+        },
+        "source": "REALTIME",
+        "metrics": ["status"],
+        "innerSelect": ["stage", "success_total", "total", "min_hits", "no_of_states"],
+        "secondInnerSelect": ["stage", "success_total", "total", "time_bucket", "merchant_id", "product_integrated", "platform"]
+    }
+    
+    if platform != "Backend":
+        api_payload_obj["filters"]["platform"] = [platform]
+    
+    api_payload = [api_payload_obj]
+    
+    host = await get_juspay_host_from_api(meta_info=meta_info)
+    domain = "agnostic" if platform == "Backend" else "nonagnostic"
+    api_url = f"{host}/{integrationSuffix}/integration-monitoring/v1/{domain}/status"
+    
+    return await post(api_url, api_payload, None, meta_info)
+
+
+async def get_x_mid_monitoring_juspay(payload: dict, meta_info: dict = None) -> dict:
+    """
+    Retrieves X-Mid monitoring metrics to check if x_merchant_id is being passed to API calls.
+    
+    This API provides insights on whether x_merchant_id is being properly passed to various
+    API endpoints, helping identify integration issues related to merchant ID validation.
+    
+    Args:
+        payload (dict): Contains merchant_id, start_time and end_time for the query range
+        meta_info (dict): Optional metadata
+        
+    Returns:
+        dict: Contains validation status for each API endpoint
+    """
+
+    api_payload = [{
+        "timeRange": {
+            "startTime": payload["start_time"],
+            "endTime": payload["end_time"]
+        },
+        "groupByNames": ["api_shortcode"],
+        "filters": {
+            "merchant_id": [payload["merchant_id"]],
+            "status_code": [200]
+        },
+        "source": "REALTIME",
+        "metrics": ["validate_xmid"]
+    }]
+    
+    host = await get_juspay_host_from_api(meta_info=meta_info)
+    api_url = f"{host}/{integrationSuffix}/integration-monitoring/v1/xmerchant/metrics"
+
+    return await post(api_url, api_payload, None, meta_info)
+
+
+async def get_integration_platform_metrics_juspay(payload: dict, meta_info: dict = None) -> dict:
+    """
+    Retrieves integration metrics grouped by platform for product integration analysis.
+    
+    This API is used for:
+    - Platform dropdown population with available platforms (Android, IOS, Web, Backend)
+    - Platform-specific content and completion percentage calculation
+    
+    Args:
+        payload (dict): Contains merchant_id, start_time, end_time
+        meta_info (dict): Optional metadata
+        
+    Returns:
+        dict: Platform-grouped product integration data with queryString, queryData, and metaData
+    """
+
+    api_payload = [{
+        "timeRange": {
+            "startTime": payload["start_time"],
+            "endTime": payload["end_time"]
+        },
+        "groupByNames": ["platform"],
+        "filters": {
+            "merchant_id": [payload["merchant_id"]]
+        },
+        "source": "REALTIME",
+        "metrics": ["product"],
+        "innerSelect": [
+            "platform",
+            "product_integrated", 
+            "time_bucket"
+        ],
+        "secondInnerSelect": [
+            "platform",
+            "product_integrated",
+            "time_bucket",
+            "merchant_id"
+        ]
+    }]
+    
+    host = await get_juspay_host_from_api(meta_info=meta_info)
+    api_url = f"{host}/{integrationSuffix}/integration-monitoring/v1/integrations/metrics"
+
+    return await post(api_url, api_payload, None, meta_info)
+
+
+async def get_integration_product_count_metrics_juspay(payload: dict, meta_info: dict = None) -> dict:
+    """
+    Retrieves integration metrics grouped by product_integrated for product count analysis.
+    
+    This API is used for:
+    - Product selection logic (product with max count becomes default)
+    - Dynamic product array creation for product dropdown population
+    - Integration health calculation and most actively used integration type identification
+    
+    Args:
+        payload (dict): Contains merchant_id, platform, start_time, end_time
+        meta_info (dict): Optional metadata
+        
+    Returns:
+        dict: Product-grouped integration count data with queryString, queryData, and metaData
+    """
+    
+    api_payload = [{
+        "timeRange": {
+            "startTime": payload["start_time"],
+            "endTime": payload["end_time"]
+        },
+        "groupByNames": ["product_integrated"],
+        "filters": {
+            "merchant_id": [payload["merchant_id"]],
+            "platform": [payload["platform"]]
+        },
+        "source": "REALTIME",
+        "metrics": ["product_count"],
+        "innerSelect": [
+            "product_integrated",
+            "time_bucket"
+        ],
+        "secondInnerSelect": [
+            "product_integrated",
+            "time_bucket",
+            "merchant_id",
+            "platform"
+        ]
+    }]
+    
+    host = await get_juspay_host_from_api(meta_info=meta_info)
+    api_url = f"{host}/{integrationSuffix}/integration-monitoring/v1/integrations/metrics"
+    return await post(api_url, api_payload, None, meta_info)

--- a/juspay_dashboard_mcp/api/settings.py
+++ b/juspay_dashboard_mcp/api/settings.py
@@ -4,7 +4,9 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
 
-from juspay_dashboard_mcp.api.utils import post, get_admin_host, get_juspay_host_from_api, sanitize_merchant_id
+import json
+
+from juspay_dashboard_mcp.api.utils import post, put, get_admin_host, get_juspay_host_from_api, sanitize_merchant_id
 
 async def get_conflict_settings_juspay(payload: dict, meta_info: dict = None) -> dict:
     """
@@ -323,5 +325,60 @@ async def get_webhook_settings_juspay(payload: dict, meta_info: dict = None) -> 
         api_url = f"{host}/ec/v1/admin/webhook"
     else:
         api_url = f"{host}/api/ec/v1/webhook"
-    
+
     return await post(api_url, request_data, None, meta_info)
+
+
+async def update_general_settings_juspay(payload: dict, meta_info: dict = None):
+    """Update the merchant's general settings.
+
+    Currently exposes only `returnUrl` (the payment redirect URL). Pass an
+    empty string to clear it. No client-side validation on the value.
+    """
+    host = await get_juspay_host_from_api(meta_info=meta_info)
+    request_payload = {"returnUrl": payload.get("returnUrl", "")}
+    api_url = f"{host}/api/ec/v1/general"
+    return await put(api_url, request_payload, None, meta_info)
+
+
+async def update_webhook_settings_juspay(payload: dict, meta_info: dict = None):
+    """Update the merchant's webhook URL and event subscriptions.
+
+    Builds the `webhookConfigs` JSON string from a fixed template plus the
+    caller-supplied `webhookEvents` map, then PUTs it to the webhook settings
+    endpoint alongside the URL and optional basic-auth credentials.
+
+    Replaces the existing webhook configuration — events the caller doesn't
+    include are unsubscribed.
+    """
+    host = await get_juspay_host_from_api(meta_info=meta_info)
+
+    # The API expects {event_name: true} for each subscribed event. The tool
+    # surfaces a plain list of event names; we build the dict here so the
+    # caller doesn't have to think about the wire format.
+    events_map = {event: True for event in payload.get("webhookEvents") or []}
+    webhook_config = {
+        "addFullGatewayResponse": False,
+        "shouldSendSSLCertBasedWebhoooks": False,
+        "trimWebhookResponse": False,
+        "webhookEvents": events_map,
+        "multiWebhookUrlConfigs": [],
+    }
+
+    body = {
+        "webHookurl": payload["webHookurl"],
+        "webhookConfigs": json.dumps(webhook_config),
+        # Always send empty — the dashboard's "save webhook" call does the
+        # same. Not exposed as a tool argument; if we ever need to vary it
+        # we can add it back to the schema.
+        "webHookapiversion": "",
+    }
+    # Only include creds when the caller actually provided them — sending
+    # empty strings would overwrite an existing username/password with blanks.
+    if payload.get("webHookUsername"):
+        body["webHookUsername"] = payload["webHookUsername"]
+    if payload.get("webHookPassword"):
+        body["webHookPassword"] = payload["webHookPassword"]
+
+    api_url = f"{host}/api/ec/v1/webhook"
+    return await put(api_url, body, None, meta_info)

--- a/juspay_dashboard_mcp/api/utils.py
+++ b/juspay_dashboard_mcp/api/utils.py
@@ -56,8 +56,8 @@ async def post(api_url: str, payload: dict,additional_headers: dict = None, meta
     juspay_creds = get_juspay_credentials()
     if not juspay_creds and meta_info:
         juspay_creds = meta_info.get("juspay_credentials")
-    
-    headers = get_common_headers(payload, meta_info, juspay_creds) 
+
+    headers = get_common_headers(payload, meta_info, juspay_creds)
 
     if additional_headers:
         headers.update(additional_headers)
@@ -76,6 +76,42 @@ async def post(api_url: str, payload: dict,additional_headers: dict = None, meta
             raise Exception(f"Juspay API HTTPError ({e.response.status_code if e.response else 'Unknown status'}): {error_content}") from e
         except Exception as e:
             logger.error(f"Error during Juspay API call: {e}")
+            raise Exception(f"Failed to call Juspay API: {e}") from e
+
+
+async def put(api_url: str, payload: dict, additional_headers: dict = None, meta_info: dict = None):
+    """PUT a JSON body to a Juspay dashboard endpoint.
+
+    Same auth/header plumbing as `post()`. Tolerant of non-JSON response
+    bodies — some Portal endpoints return a plain `"Success"` string instead
+    of a JSON object; we fall back to the raw text so the tool can return
+    something useful either way.
+    """
+    juspay_creds = get_juspay_credentials()
+    if not juspay_creds and meta_info:
+        juspay_creds = meta_info.get("juspay_credentials")
+
+    headers = get_common_headers(payload, meta_info, juspay_creds)
+    if additional_headers:
+        headers.update(additional_headers)
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            logger.info(f"PUT {api_url} body={payload} headers={headers}")
+            response = await client.put(api_url, headers=headers, json=payload)
+            response.raise_for_status()
+            try:
+                response_data = response.json()
+            except ValueError:
+                response_data = response.text
+            logger.info(f"API Response: {response_data}")
+            return response_data
+        except httpx.HTTPStatusError as e:
+            error_content = e.response.text if e.response else "Unknown error"
+            logger.error(f"HTTP error: {e.response.status_code if e.response else 'No response'} - {error_content}")
+            raise Exception(f"Juspay API HTTPError ({e.response.status_code if e.response else 'Unknown status'}): {error_content}") from e
+        except Exception as e:
+            logger.error(f"Error during Juspay PUT call: {e}")
             raise Exception(f"Failed to call Juspay API: {e}") from e
         
 
@@ -101,6 +137,11 @@ async def get_juspay_host_from_api(token: str = None, headers: dict = None, meta
     
     token_response = (meta_info or {}).get("token_response") or {}
     auth_type = token_response.get("auth_type")
+    # Fall back to the request-scoped creds dict — OAuth bearer middleware
+    # tags it with auth_type="oauth" so tools don't have to receive meta_info
+    # explicitly to choose the OAuth validation endpoint.
+    if not auth_type and juspay_creds:
+        auth_type = juspay_creds.get("auth_type")
 
     try:
         if auth_type == "oauth":
@@ -172,6 +213,11 @@ async def get_admin_host(token: str = None, headers: dict = None ,meta_info: dic
 
     token_response = (meta_info or {}).get("token_response") or {}
     auth_type = token_response.get("auth_type")
+    # Fall back to the request-scoped creds dict — OAuth bearer middleware
+    # tags it with auth_type="oauth" so tools don't have to receive meta_info
+    # explicitly to choose the OAuth validation endpoint.
+    if not auth_type and juspay_creds:
+        auth_type = juspay_creds.get("auth_type")
 
     try:
         if auth_type == "oauth":

--- a/juspay_dashboard_mcp/api_schema/account.py
+++ b/juspay_dashboard_mcp/api_schema/account.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+
+from juspay_dashboard_mcp.api_schema.headers import WithHeaders
+
+
+class JuspayGetMerchantDetailsPayload(WithHeaders):
+    """Return merchant and user details for the authenticated session.
+
+    Takes no input arguments — Portal derives everything from the bearer
+    token presented on the request.
+    """
+    pass

--- a/juspay_dashboard_mcp/api_schema/api_keys.py
+++ b/juspay_dashboard_mcp/api_schema/api_keys.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+
+from pydantic import Field
+from juspay_dashboard_mcp.api_schema.headers import WithHeaders
+
+
+class JuspayCreateApiKeyPayload(WithHeaders):
+    """Generate a new API key for the merchant.
+
+    The returned `apiKey` is shown only once at creation — the dashboard
+    keeps only its masked form afterwards.
+    """
+
+    description: str = Field(
+        ...,
+        description=(
+            "Human-readable label for the key (shown in the merchant's API "
+            "Keys listing). Keep it short and identifiable, e.g. "
+            "'mcp-cli-2026-05'."
+        ),
+    )

--- a/juspay_dashboard_mcp/api_schema/integrationChecklist.py
+++ b/juspay_dashboard_mcp/api_schema/integrationChecklist.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+
+from typing import Literal, Optional, List
+from pydantic import BaseModel, Field, validator
+from datetime import datetime
+from juspay_dashboard_mcp.api_schema.headers import WithHeaders
+
+
+class BaseTimeRangePayload(WithHeaders):
+    """Base class for payloads that include time range validation."""
+    
+    @validator('start_time', 'end_time', check_fields=False)
+    def validate_datetime_format(cls, v):
+        try:
+            datetime.fromisoformat(v.replace('Z', '+00:00'))
+            return v
+        except ValueError:
+            raise ValueError('Time must be in ISO format: YYYY-MM-DDTHH:MM:SSZ')
+
+
+class JuspayIntegrationStatusPayload(BaseTimeRangePayload):
+    platform: Literal["Backend", "Web", "Android", "IOS"] = Field(
+        ...,
+        description="Platform type. Use 'Backend' for agnostic API, or 'Web'/'Android'/'IOS' for nonagnostic API."
+    )
+    product_integrated: Literal["Payment Page Signature", "Payment Page Session", "EC + SDK", "EC Only"] = Field(
+        ...,
+        description="Product integration type ('Payment Page Signature', 'EC + SDK', 'Payment Page Session', 'EC Only')"
+    )
+    merchant_id: str = Field(
+        ...,
+        description="Merchant identifier (e.g., 'A23Games', '1mgtech')"
+    )
+    start_time: str = Field(
+        ...,
+        description="Start time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-08-03T00:00:00Z')"
+    )
+    end_time: str = Field(
+        ...,
+        description="End time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-09-01T12:50:00Z')"
+    )
+
+
+class JuspayXMidMonitoringPayload(BaseTimeRangePayload):
+    merchant_id: str = Field(
+        ...,
+        description="Merchant identifier (e.g., '12club', 'A23Games')"
+    )
+    start_time: str = Field(
+        ...,
+        description="Start time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-08-10T00:00:00Z')"
+    )
+    end_time: str = Field(
+        ...,
+        description="End time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-09-08T15:50:00Z')"
+    )
+
+
+class JuspayIntegrationPlatformMetricsPayload(BaseTimeRangePayload):
+    merchant_id: str = Field(
+        ...,
+        description="Merchant identifier (e.g., '12club', 'A23Games')"
+    )
+    start_time: str = Field(
+        ...,
+        description="Start time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-08-10T00:00:00Z')"
+    )
+    end_time: str = Field(
+        ...,
+        description="End time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-09-08T15:50:00Z')"
+    )
+
+
+class JuspayIntegrationProductCountMetricsPayload(BaseTimeRangePayload):
+    merchant_id: str = Field(
+        ...,
+        description="Merchant identifier (e.g., 'pokerindia', 'A23Games')"
+    )
+    start_time: str = Field(
+        ...,
+        description="Start time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-08-10T00:00:00Z')"
+    )
+    end_time: str = Field(
+        ...,
+        description="End time in ISO format: YYYY-MM-DDTHH:MM:SSZ (e.g., '2025-09-08T18:40:00Z')"
+    )
+    platform: Optional[str] = Field(
+        None,
+        description="Optional platform filter (e.g., '', 'Android', 'IOS', 'Web')"
+    )

--- a/juspay_dashboard_mcp/api_schema/settings.py
+++ b/juspay_dashboard_mcp/api_schema/settings.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
 
-from typing import Optional
+from typing import List, Optional
 from pydantic import BaseModel, Field
 
 from juspay_dashboard_mcp.api_schema.headers import WithHeaders
@@ -34,3 +34,66 @@ class JuspayRoutingSettingsPayload(WithHeaders):
 class JuspayWebhookSettingsPayload(WithHeaders):
     """Schema for webhook settings API."""
     pass  # No specific fields required beyond the common headers
+
+
+class JuspayUpdateGeneralSettingsPayload(WithHeaders):
+    """Update payload for the merchant's general settings.
+
+    Currently exposes only `returnUrl` (the payment redirect URL). Pass an
+    empty string to clear it.
+    """
+
+    returnUrl: str = Field(
+        ...,
+        description=(
+            "Payment redirect URL the merchant's customer is sent back to "
+            "after the Juspay-hosted payment flow completes. Pass an empty "
+            "string to clear/unset."
+        ),
+    )
+
+
+class JuspayUpdateWebhookSettingsPayload(WithHeaders):
+    """Update the webhook URL and event subscriptions for the merchant.
+
+    `webhookEvents` REPLACES the merchant's full event subscription map —
+    events not listed will be unsubscribed. The handler internally rebuilds
+    the `webhookConfigs` JSON with defaults for the boilerplate flags
+    (addFullGatewayResponse, trimWebhookResponse, etc.) so the caller only
+    needs to think about URL + events + optional basic-auth credentials.
+    """
+
+    webHookurl: str = Field(
+        ...,
+        description=(
+            "URL Juspay will POST event notifications to. Must be a fully "
+            "qualified HTTPS URL reachable from Juspay's infrastructure."
+        ),
+    )
+    webhookEvents: List[str] = Field(
+        ...,
+        description=(
+            "List of Juspay event names to subscribe to. Example: "
+            "[\"ORDER_SUCCEEDED\", \"ORDER_FAILED\", \"TXN_CHARGED\"]. "
+            "Common event names include ORDER_SUCCEEDED, ORDER_FAILED, "
+            "ORDER_CREATED, ORDER_AUTHORIZED, TXN_CREATED, TXN_CHARGED, "
+            "MANDATE_CREATED, MANDATE_ACTIVATED, MANDATE_REVOKED, "
+            "MANDATE_FAILED, NOTIFICATION_SUCCEEDED, TOKEN_STATUS_CREATED, "
+            "TOKEN_STATUS_UPDATED, CHARGEBACK_ALREADY_REFUNDED. Pass an "
+            "empty list to unsubscribe from all events."
+        ),
+    )
+    webHookUsername: Optional[str] = Field(
+        None,
+        description=(
+            "Optional HTTP basic-auth username Juspay will use when calling "
+            "the webhook URL."
+        ),
+    )
+    webHookPassword: Optional[str] = Field(
+        None,
+        description=(
+            "Optional HTTP basic-auth password Juspay will use when calling "
+            "the webhook URL."
+        ),
+    )

--- a/juspay_dashboard_mcp/config.py
+++ b/juspay_dashboard_mcp/config.py
@@ -76,14 +76,21 @@ def get_common_headers(payload: dict, meta_info: dict = None, juspay_creds: dict
 
     default_headers["x-web-logintoken"] = token
 
-    if payload.get("tenant_id"):
-        default_headers["x-tenant-id"] = payload.pop("tenant_id")
+    # Some Juspay endpoints (e.g. integration monitoring) take a list as the
+    # request body. The header-from-payload extraction below only makes sense
+    # for dict bodies — guard accordingly so list payloads no longer crash
+    # with `'list' object has no attribute 'get'`.
+    if isinstance(payload, dict):
+        if payload.get("tenant_id"):
+            default_headers["x-tenant-id"] = payload.pop("tenant_id")
 
-    if payload.get("cookie"):
-        default_headers["cookie"] = payload.pop("cookie")
+        if payload.get("cookie"):
+            default_headers["cookie"] = payload.pop("cookie")
 
-    if payload.get("x-source-id"):
-        default_headers["x-source-id"] = payload.pop("x-source-id")
+        if payload.get("x-source-id"):
+            default_headers["x-source-id"] = payload.pop("x-source-id")
+        else:
+            default_headers["x-source-id"] = "juspay-mcp"
     else:
         default_headers["x-source-id"] = "juspay-mcp"
 

--- a/juspay_dashboard_mcp/response_schema.py
+++ b/juspay_dashboard_mcp/response_schema.py
@@ -1535,3 +1535,291 @@ rag_query_response_schema = {
     "required": ["response", "query", "model", "sources"],
     "additionalProperties": True,
 }
+
+integration_monitoring_status_response_schema = {
+    "type": "object",
+    "properties": {
+        "queryString": {
+            "type": "array",
+            "description": "Query parameters used for the request"
+        },
+        "uuid": {
+            "type": "string",
+            "description": "Unique identifier for the analytics query"
+        },
+        "queryData": {
+            "type": "object",
+            "properties": {
+                "success": {
+                    "type": "boolean",
+                    "description": "Whether the query was successful"
+                },
+                "scoreData": {
+                    "type": "object",
+                    "description": "Feature-wise score metrics for integration monitoring. Keys are dynamic based on features (e.g., baseCriticalSuccessCount, mandateTotalCount, payoutSuccessCount, etc.)",
+                    "additionalProperties": True,
+                    "examples": [
+                        {
+                            "baseCriticalSuccessCount": 1,
+                            "baseCriticalTotalCount": 7,
+                            "baseTotalSuccessCount": 1,
+                            "baseTotalCount": 9,
+                            "mandateTotalCount": 5,
+                            "mandateSuccessCount": 3,
+                            "payoutCriticalSuccessCount": 2,
+                            "payoutCriticalTotalCount": 4
+                        }
+                    ]
+                },
+                "responseData": {
+                    "type": "object",
+                    "properties": {
+                        "moduleDescription": {"type": "string"},
+                        "disableModule": {"type": "boolean"},
+                        "features": {
+                            "type": "object",
+                            "description": "Feature-wise (e.g., base, mandate, payout etc.) integration monitoring data",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {
+                                    "featureDescription": {"type": "string"},
+                                    "disableFeature": {"type": "boolean"},
+                                    "sections": {
+                                        "type": "object",
+                                        "description": "Sections within each feature (e.g., 'Payments Flow Checklist')",
+                                        "additionalProperties": {
+                                            "type": "object",
+                                            "properties": {
+                                                "sectionDescription": {"type": "string"},
+                                                "sectionNote": {"type": "string"},
+                                                "disableSection": {"type": "boolean"},
+                                                "stages": {
+                                                    "type": "object",
+                                                    "description": "Individual stages within each section",
+                                                    "additionalProperties": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "status": {
+                                                                "type": "string",
+                                                                "description": "Stage status (e.g., 'NOT_ATTEMPTED', 'PASSED', 'FAILED')"
+                                                            },
+                                                            "stageDisplayName": {"type": "string"},
+                                                            "stageDescription": {"type": "string"},
+                                                            "stageNote": {"type": "string"},
+                                                            "disableStage": {"type": "boolean"},
+                                                            "critical": {"type": "string"},
+                                                            "visibility": {"type": "string"},
+                                                            "onlyReport": {"type": "string"},
+                                                            "criticalResult": {"type": "boolean"},
+                                                            "visibilityResult": {"type": "boolean"},
+                                                            "onlyReportResult": {"type": "boolean"},
+                                                            "moduleMetadata": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "noOfStates": {"type": "integer"},
+                                                                    "productIntegrated": {
+                                                                        "type": "array",
+                                                                        "items": {"type": "string"}
+                                                                    },
+                                                                    "isPlatformDependent": {"type": "boolean"},
+                                                                    "minHitsRequired": {"type": "string"}
+                                                                },
+                                                                "required": ["noOfStates", "productIntegrated", "isPlatformDependent", "minHitsRequired"]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "status", "stageDisplayName", "stageDescription", "stageNote",
+                                                            "disableStage", "critical", "visibility", "onlyReport",
+                                                            "criticalResult", "visibilityResult", "onlyReportResult", "moduleMetadata"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": ["sectionDescription", "sectionNote", "disableSection", "stages"]
+                                        }
+                                    }
+                                },
+                                "required": ["featureDescription", "disableFeature", "sections"]
+                            }
+                        }
+                    },
+                    "required": ["moduleDescription", "disableModule", "features"]
+                }
+            },
+            "required": ["success", "scoreData", "responseData"]
+        }
+    },
+    "required": ["queryData"]
+}
+
+x_mid_monitoring_response_schema = {
+    "type": "object",
+    "properties": {
+        "queryString": {
+            "type": "array",
+            "description": "Actual Select Query for the request"
+        },
+        "uuid": {
+            "type": "string",
+            "description": "Unique identifier for the analytics query"
+        },
+        "queryStatus": {
+            "type": "object",
+            "description": "Status information about the query execution"
+        },
+        "queryData": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "api_shortcode": {
+                        "type": "string",
+                        "description": "API shortcode identifier"
+                    },
+                    "validate_xmid": {
+                        "type": "string",
+                        "description": "X-Mid validation result (PASSED/FAILED)"
+                    }
+                },
+                "required": ["api_shortcode", "validate_xmid"]
+            }
+        },
+        "metaData": {
+            "type": "array",
+            "description": "Additional metadata about the query"
+        }
+    },
+    "required": ["queryData"]
+}
+
+integration_platform_metrics_response_schema = {
+    "type": "object",
+    "properties": {
+        "queryString": {
+            "type": "array",
+            "description": "Generated SQL query for platform-based metrics",
+            "items": {"type": "string"}
+        },
+        "uuid": {
+            "type": "string",
+            "description": "Unique identifier for the analytics query (e.g., 'analytics-UUID-821482cf-ed31-4a3b-9102-02e16b692242')"
+        },
+        "queryStatus": {
+            "type": "object",
+            "description": "Status information about the query execution"
+        },
+        "queryData": {
+            "type": "array",
+            "description": "Platform-grouped product integration data",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "platform": {
+                        "type": "string",
+                        "description": "Platform identifier (e.g., '', 'Android', 'IOS', 'Web')"
+                    },
+                    "product": {
+                        "type": "string",
+                        "description": "Product integration type (e.g., 'Payment Page Signature', 'EC + SDK')"
+                    }
+                },
+                "required": ["platform", "product"]
+            }
+        },
+        "metaData": {
+            "type": "array",
+            "description": "Additional metadata about the query including time range",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "currentTimeRange": {
+                        "type": "object",
+                        "properties": {
+                            "startTime": {
+                                "type": "string",
+                                "description": "Query start time in ISO format"
+                            },
+                            "endTime": {
+                                "type": "string", 
+                                "description": "Query end time in ISO format"
+                            }
+                        },
+                        "required": ["startTime", "endTime"]
+                    },
+                    "requestPrefix": {
+                        "type": "string",
+                        "description": "Request prefix identifier"
+                    }
+                },
+                "required": ["currentTimeRange", "requestPrefix"]
+            }
+        }
+    },
+    "required": ["queryData"]
+}
+
+integration_product_count_metrics_response_schema = {
+    "type": "object",
+    "properties": {
+        "queryString": {
+            "type": "array",
+            "description": "Generated SQL query for product count metrics",
+            "items": {"type": "string"}
+        },
+        "uuid": {
+            "type": "string",
+            "description": "Unique identifier for the analytics query (e.g., 'analytics-UUID-9f9fa9d1-bc68-4fa3-8140-b435e6130972')"
+        },
+        "queryStatus": {
+            "type": "object",
+            "description": "Status information about the query execution"
+        },
+        "queryData": {
+            "type": "array",
+            "description": "Product integration count data grouped by product_integrated",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "product_integrated": {
+                        "type": "string",
+                        "description": "Product integration type (e.g., '', 'EC + SDK', 'Payment Page Session')"
+                    },
+                    "product_count": {
+                        "type": "integer",
+                        "description": "Count of transactions for this product integration type"
+                    }
+                },
+                "required": ["product_integrated", "product_count"]
+            }
+        },
+        "metaData": {
+            "type": "array",
+            "description": "Additional metadata about the query including time range",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "currentTimeRange": {
+                        "type": "object",
+                        "properties": {
+                            "startTime": {
+                                "type": "string",
+                                "description": "Query start time in ISO format"
+                            },
+                            "endTime": {
+                                "type": "string",
+                                "description": "Query end time in ISO format"
+                            }
+                        },
+                        "required": ["startTime", "endTime"]
+                    },
+                    "requestPrefix": {
+                        "type": "string",
+                        "description": "Request prefix identifier"
+                    }
+                },
+                "required": ["currentTimeRange", "requestPrefix"]
+            }
+        }
+    },
+    "required": ["queryData"]
+}

--- a/juspay_dashboard_mcp/tools.py
+++ b/juspay_dashboard_mcp/tools.py
@@ -33,6 +33,18 @@ def get_juspay_request_credentials():
 
 AVAILABLE_TOOLS = [
     util.make_api_config(
+        name="juspay_get_merchant_details",
+        description="""Return merchant and user session details for the authenticated caller.
+
+Key features:
+- Returns merchantId, userId, email, username, tenantAccountId, validHost, and the caller's context (MERCHANT / TENANT / RESELLER / JUSPAY).
+- Takes no input — all information is derived from the active session.
+
+Use this when the user asks who they are, which merchant or tenant they're logged in as, what their merchant ID / user ID / tenant ID is, or to confirm session context before performing privileged actions.""",
+        model=api_schema.account.JuspayGetMerchantDetailsPayload,
+        handler=account.get_merchant_details_juspay,
+    ),
+    util.make_api_config(
         name="juspay_list_configured_gateway",
         description="""Use this tool when asked about the list of payment gateways . Retrieves a list of all payment gateways (PGs) configured for a merchant, including high-level details such as gateway reference ID, creation/modification dates, configured payment methods (PMs) and configured payment flows. Note: Payment Method Types (PMTs), configured EMI plans, configured mandate/subscriptions payment methods (PMs) and configured TPV PMs are not included in the response.
 
@@ -274,6 +286,50 @@ Use this tool to verify webhook configurations and troubleshoot notification del
         model=api_schema.settings.JuspayWebhookSettingsPayload,
         handler=settings.get_webhook_settings_juspay,
         response_schema=response_schema.get_webhook_settings_response_schema,
+    ),
+    util.make_api_config(
+        name="juspay_update_webhook_settings",
+        description="""Update the merchant's webhook URL and event subscriptions.
+
+Key features:
+- Sets the URL Juspay will POST event notifications to.
+- Selects which events the merchant subscribes to (e.g. ORDER_SUCCEEDED, ORDER_FAILED, TXN_CHARGED, MANDATE_CREATED).
+- Optionally configures HTTP basic-auth credentials Juspay should use when calling the webhook URL.
+
+Important caveats — warn the user before calling this:
+- `webhookEvents` REPLACES the current subscription map. Events the caller doesn't include get unsubscribed. To preserve existing events, fetch them first with `juspay_get_webhook_settings` and merge.
+- Advanced webhook config fields (custom webhook URL routes, JWT key references, full-gateway-response toggle, SSL-cert-based webhooks) are reset to defaults by this tool. Don't use it on merchants that depend on those — modify those via the dashboard instead.
+
+Use this when the user asks to configure webhooks, set their webhook URL, or change which Juspay events they receive.""",
+        model=api_schema.settings.JuspayUpdateWebhookSettingsPayload,
+        handler=settings.update_webhook_settings_juspay,
+    ),
+    util.make_api_config(
+        name="juspay_create_api_key",
+        description="""Generate a new API key for the authenticated merchant.
+
+Key features:
+- Creates a new ACTIVE API key bound to the caller's merchant account.
+- The plaintext `apiKey` is returned ONCE in the response — store it immediately; the dashboard only retains its masked form afterwards.
+- Accepts a `description` for identification in the API Keys listing.
+- Returns: id, status (ACTIVE), apiKey, maskedApiKey, scope, dateCreated, lastUpdated, merchantAccountId, version, metadata.
+
+Use this when the user asks to generate, mint, or provision a Juspay API key for server-to-server payment API access. Warn the user that the plaintext key cannot be retrieved later — it must be saved at creation time.""",
+        model=api_schema.api_keys.JuspayCreateApiKeyPayload,
+        handler=api_keys.create_api_key_juspay,
+    ),
+    util.make_api_config(
+        name="juspay_update_general_settings",
+        description="""Update the merchant's general settings.
+
+Key features:
+- Currently updates the payment redirect URL (`returnUrl`) — the URL the customer is sent back to after the Juspay-hosted payment flow completes.
+- Pass an empty string to clear/unset the redirect URL.
+- No client-side validation on the value.
+
+Use this when the user asks to set, change, or clear the payment redirect URL / return URL for their merchant account.""",
+        model=api_schema.settings.JuspayUpdateGeneralSettingsPayload,
+        handler=settings.update_general_settings_juspay,
     ),
     util.make_api_config(
         name="juspay_alert_details",

--- a/juspay_dashboard_mcp/tools.py
+++ b/juspay_dashboard_mcp/tools.py
@@ -501,6 +501,141 @@ CRITICAL : If all the necessary parameters are provided do not ask for confirmat
     handler=rag_tool.query_rag_tool,
     response_schema=response_schema.rag_query_response_schema,
     ),
+    # ----- Integration Checklist tools (ported from PR #67) -------------------
+    util.make_api_config(
+        name="juspay_integration_monitoring_status",
+        description="""Track integration progress across platforms and products for a particular merchant. Use this tool when you need to view passed/failed stages and action items for merchant integrations.
+
+**When to call this tool:**
+- When asked about integration status, progress, or completion for a specific merchant
+- To check which integration stages/items have passed or failed
+- To identify action items and next steps for integration completion
+- When troubleshooting integration issues or blockers
+- To view detailed stage-wise breakdown of integration checklist
+- When user asks about integration status and doesn't mention platform or product_integrated, first call `juspay_integration_platform_metrics` to get the default platform, then `juspay_integration_product_count_metrics` to get the default product_integrated for that platform, then call this tool with both.
+
+**Tool capabilities:**
+- Platform-aware monitoring (Backend uses agnostic API, Web/Android/iOS use nonagnostic API)
+- Stage-wise integration progress tracking with pass/fail status
+- Critical vs non-critical stage identification for prioritization
+- Feature-wise analysis (base payments, mandate, payout, etc.)
+- Visibility conditions and actionable results for each stage
+- Integration checklist completion tracking
+
+**Required inputs:**
+- platform: Must be one of "Backend", "Web", "Android", "iOS"
+- product_integrated: Must be one of "Payment Page Signature", "Payment Page Session", "EC + SDK", "EC Only"
+- merchant_id: Merchant ID
+- start_time / end_time: ISO format YYYY-MM-DDTHH:MM:SSZ. Convert natural language windows (last N days) to absolute timestamps.
+- Date range limit: only last 45 days of data is available — refuse older windows.
+- Default range: last 30 days when the user doesn't specify one.
+
+**Response provides:**
+- Overall integration completion status with critical stage counts
+- Feature-wise progress breakdown (base, mandate, payout, etc.)
+- Section-wise analysis (e.g., "Payments Flow Checklist")
+- Individual stage details with pass/fail status, criticality level, and action items
+- Module metadata including platform dependencies and minimum requirements
+
+Use this tool to monitor integration progress, identify failed stages that need attention, and provide actionable guidance for completing merchant integrations.""",
+        model=api_schema.integrationChecklist.JuspayIntegrationStatusPayload,
+        handler=integrationChecklist.get_integration_monitoring_status_juspay,
+        response_schema=response_schema.integration_monitoring_status_response_schema,
+    ),
+    util.make_api_config(
+        name="juspay_x_mid_monitoring",
+        description="""Retrieves X-Mid validation monitoring data for merchant transactions.
+
+This tool provides X-Mid validation results for API transactions within a specified time range, helping merchants monitor the validation status of their X-Mid headers across different API endpoints.
+
+Key features:
+- Time-range based X-Mid validation monitoring
+- API shortcode-wise validation results
+- PASSED/FAILED validation status tracking
+- Merchant-specific validation data
+
+Required inputs:
+- merchant_id: Merchant ID for which to retrieve X-Mid validation data
+- start_time / end_time: ISO format YYYY-MM-DDTHH:MM:SSZ. Convert natural language windows (last N days) to absolute timestamps.
+- Date range limit: only last 45 days of data is available — refuse older windows.
+- Default range: last 30 days when the user doesn't specify one.
+
+Response includes:
+- Query metadata and execution status
+- Array of validation results with API shortcodes
+- Validation status (PASSED/FAILED) for each API endpoint/shortcode
+
+Use this tool to monitor X-Mid header validation compliance, track validation failures across different API endpoints, and ensure proper X-Mid implementation for merchant transactions.""",
+        model=api_schema.integrationChecklist.JuspayXMidMonitoringPayload,
+        handler=integrationChecklist.get_x_mid_monitoring_juspay,
+        response_schema=response_schema.x_mid_monitoring_response_schema,
+    ),
+    util.make_api_config(
+        name="juspay_integration_platform_metrics",
+        description="""Retrieve available platforms for a particular merchant. Returns the list of platforms (Android, iOS, Web) configured for the merchant.
+
+**When to call this tool:**
+- When you need to get the list of available platforms for a merchant
+- To determine which platforms are configured for a merchant
+- When you need to get the default platform for subsequent API calls
+- When asked about integration progress across different platforms
+- To compare integration completion between Android, iOS, Web, and Backend platforms
+
+**Tool capabilities:**
+- Groups integration data by platform (Android, iOS, Web — Backend must be added separately by the caller)
+- First platform in response becomes the default platform
+
+**Required inputs:**
+- merchant_id: Merchant ID for platform metrics analysis
+- start_time / end_time: ISO format YYYY-MM-DDTHH:MM:SSZ. Convert natural language windows (last N days) to absolute timestamps.
+- Date range limit: only last 45 days of data is available — refuse older windows.
+- Default range: last 30 days when the user doesn't specify one.
+
+**Response provides:**
+- Platform-grouped data (typically Android, iOS, Web)
+- Platform list for the merchant
+
+**Important note:** API typically returns Android, iOS, and Web platforms only. Add Backend separately for full coverage.
+
+Use this tool to get the list of available platforms for a merchant, not for integration status tracking.""",
+        model=api_schema.integrationChecklist.JuspayIntegrationPlatformMetricsPayload,
+        handler=integrationChecklist.get_integration_platform_metrics_juspay,
+        response_schema=response_schema.integration_platform_metrics_response_schema,
+    ),
+    util.make_api_config(
+        name="juspay_integration_product_count_metrics",
+        description="""Analyze integration usage patterns by product type for a particular merchant. Use this tool when you need to understand which integration products are most actively used and their adoption patterns.
+
+**When to call this tool:**
+- When asked about product integration usage patterns or adoption rates
+- To identify the most popular integration types for a merchant
+- When analyzing integration health across different product types
+- For product selection: if user didn't provide platform, call `juspay_integration_platform_metrics` first to get the default platform, then call this tool with that platform.
+
+**Tool capabilities:**
+- Groups integration data by product_integrated type (Payment Page Signature, Payment Page Session, EC + SDK, EC Only)
+- Product usage count metrics and analytics
+- Platform-specific filtering for accurate product analysis
+- Time-range based product adoption tracking
+- Integration health calculation by product type
+- Product with highest `product_count` becomes default
+
+**Required inputs:**
+- merchant_id: Merchant ID for product count metrics analysis
+- platform: Platform filter (e.g., 'Android', 'iOS', 'Web') — mandatory for accurate filtering
+- start_time / end_time: ISO format YYYY-MM-DDTHH:MM:SSZ. Convert natural language windows (last N days) to absolute timestamps.
+- Date range limit: only last 45 days of data is available — refuse older windows.
+- Default range: last 30 days when the user doesn't specify one.
+
+**Response provides:**
+- Product-grouped data with count metrics for each integration type
+- Platform-specific product integration data
+
+Use this tool to analyze product integration patterns, identify the most actively used integration types, and understand product adoption trends for merchant integrations.""",
+        model=api_schema.integrationChecklist.JuspayIntegrationProductCountMetricsPayload,
+        handler=integrationChecklist.get_integration_product_count_metrics_juspay,
+        response_schema=response_schema.integration_product_count_metrics_response_schema,
+    ),
 ]
 
 @app.list_tools()

--- a/juspay_mcp/auth/__init__.py
+++ b/juspay_mcp/auth/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""OAuth 2.1 subsystem for juspay-mcp.
+
+Implements the MCP 2025-06 authorization profile so Claude Code (and any other
+OAuth-aware MCP client) can connect to mcp.juspay.in via the Juspay Portal
+identity provider.
+
+Layout:
+    config.py        — env-driven configuration object
+    context.py       — ContextVar holding the validated PortalUserInfo
+    metadata.py      — RFC 9728 / RFC 8414 metadata document builders
+    pkce.py          — PKCE S256 helpers
+    portal_client.py — async wrapper around portal.juspay.in OAuth endpoints
+    state_store.py   — TTL'd in-memory store for /authorize state + code rows
+    middleware.py    — Bearer auth Starlette middleware
+    routes.py        — Starlette Route list for /.well-known/* + /oauth/*
+"""

--- a/juspay_mcp/auth/config.py
+++ b/juspay_mcp/auth/config.py
@@ -1,0 +1,103 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""OAuth runtime configuration sourced from environment variables.
+
+`OAUTH_ENABLED` is the master switch: when false (the default for now) the
+existing header-based JuspayHeaderAuthMiddleware path is retained so we can
+ship this code without breaking current callers (juspay-genius, internal
+consumers, etc.). Flip to `true` on the OAuth-protected deployment.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_list(name: str, default: list[str]) -> list[str]:
+    raw = os.getenv(name)
+    if not raw:
+        return list(default)
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+DEFAULT_SCOPES = [
+    "analytics:read",
+    "orders:read",
+    "orders:write",
+    "settings:read",
+    "gateways:read",
+    "reports:read",
+    "users:read",
+    "alerts:read",
+]
+
+
+@dataclass(frozen=True)
+class OAuthConfig:
+    enabled: bool
+    mcp_server_url: str
+    portal_base_url: str
+    upstream_client_id: str
+    upstream_client_secret: str
+    scopes_supported: list[str]
+    state_ttl_seconds: int
+    validation_cache_ttl_seconds: int
+    # Dev-only: when set, any incoming bearer equal to this value is treated as
+    # an authenticated request bound to a synthetic PortalUserInfo. Lets us
+    # smoke-test the middleware + tool dispatch path without burning a real
+    # Portal token. NEVER set this in production.
+    dev_test_token: str | None = None
+    dev_test_merchant_id: str = "TEST_MERCHANT"
+    # Optional: extra hostnames that should also be considered valid canonical
+    # resource URIs (in case the deployment lives behind multiple DNS names).
+    extra_resource_hostnames: list[str] = field(default_factory=list)
+
+
+def load() -> OAuthConfig:
+    cfg = OAuthConfig(
+        enabled=_env_bool("OAUTH_ENABLED", False),
+        mcp_server_url=os.getenv("MCP_SERVER_URL", "http://localhost:8080").rstrip("/"),
+        portal_base_url=os.getenv("PORTAL_BASE_URL", "https://portal.juspay.in").rstrip("/"),
+        upstream_client_id=os.getenv("OAUTH_CLIENT_ID", ""),
+        upstream_client_secret=os.getenv("OAUTH_CLIENT_SECRET", ""),
+        scopes_supported=_env_list("OAUTH_SCOPES_SUPPORTED", DEFAULT_SCOPES),
+        state_ttl_seconds=int(os.getenv("OAUTH_STATE_TTL_SECONDS", "600")),
+        validation_cache_ttl_seconds=int(
+            os.getenv("OAUTH_VALIDATION_CACHE_TTL_SECONDS", "300")
+        ),
+        dev_test_token=os.getenv("OAUTH_DEV_TEST_TOKEN") or None,
+        dev_test_merchant_id=os.getenv("OAUTH_DEV_TEST_MERCHANT_ID", "TEST_MERCHANT"),
+        extra_resource_hostnames=_env_list("OAUTH_EXTRA_RESOURCE_HOSTNAMES", []),
+    )
+
+    if cfg.enabled:
+        logger.info(
+            "OAuth enabled — issuer=%s portal=%s scopes=%s dev_test_token=%s",
+            cfg.mcp_server_url,
+            cfg.portal_base_url,
+            cfg.scopes_supported,
+            "set" if cfg.dev_test_token else "unset",
+        )
+        if not cfg.upstream_client_id or not cfg.upstream_client_secret:
+            logger.warning(
+                "OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET not set — Portal token "
+                "exchange will fail until they are configured."
+            )
+    else:
+        logger.info("OAuth disabled — falling back to header-based auth path.")
+
+    return cfg

--- a/juspay_mcp/auth/context.py
+++ b/juspay_mcp/auth/context.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""Per-request OAuth context.
+
+Mirrors the existing `juspay_request_credentials` ContextVar pattern used by
+`juspay_mcp.tools` so tool handlers can read OAuth identity without threading
+it through every call.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PortalUserInfo:
+    merchant_id: str
+    user_id: str
+    email: str
+    context: str  # MERCHANT | TENANT | RESELLER | JUSPAY
+    username: str | None = None
+    tenant_account_id: str | None = None
+    valid_host: str | None = None
+
+
+@dataclass(frozen=True)
+class OAuthRequestContext:
+    access_token: str
+    user_info: PortalUserInfo
+
+
+_current: ContextVar[OAuthRequestContext | None] = ContextVar(
+    "juspay_mcp_oauth_context", default=None
+)
+
+
+def set_current(ctx: OAuthRequestContext | None) -> None:
+    _current.set(ctx)
+
+
+def get_current() -> OAuthRequestContext | None:
+    return _current.get()
+
+
+def clear_current() -> None:
+    _current.set(None)

--- a/juspay_mcp/auth/metadata.py
+++ b/juspay_mcp/auth/metadata.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""OAuth metadata document builders.
+
+`protected_resource_metadata` — RFC 9728 doc returned at
+`/.well-known/oauth-protected-resource` (and per-mount variants). Tells the
+MCP client which authorization server(s) issue valid tokens for this resource.
+
+`authorization_server_metadata` — RFC 8414 doc returned at
+`/.well-known/oauth-authorization-server` (and aliased at
+`/.well-known/openid-configuration` for OIDC discovery fallback). Advertises
+endpoints, supported grant types, PKCE methods, and DCR endpoint.
+"""
+
+from __future__ import annotations
+
+from .config import OAuthConfig
+
+
+def protected_resource_metadata(cfg: OAuthConfig, resource_url: str | None = None) -> dict:
+    """Build the protected-resource metadata document.
+
+    `resource_url` lets callers override the canonical resource per mount-point
+    (e.g. `…/juspay-dashboard-stream`). When omitted we advertise the bare
+    issuer URL, which Claude Code accepts.
+    """
+    return {
+        "resource": resource_url or cfg.mcp_server_url,
+        "authorization_servers": [cfg.mcp_server_url],
+        "bearer_methods_supported": ["header"],
+        "scopes_supported": cfg.scopes_supported,
+    }
+
+
+def authorization_server_metadata(cfg: OAuthConfig) -> dict:
+    base = cfg.mcp_server_url
+    return {
+        "issuer": base,
+        "authorization_endpoint": f"{base}/oauth/authorize",
+        "token_endpoint": f"{base}/oauth/token",
+        "registration_endpoint": f"{base}/oauth/register",
+        "revocation_endpoint": f"{base}/oauth/revoke",
+        "jwks_uri": f"{base}/.well-known/jwks.json",
+        "scopes_supported": cfg.scopes_supported,
+        "response_types_supported": ["code"],
+        "response_modes_supported": ["query"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_post",
+            "client_secret_basic",
+            "none",
+        ],
+        "service_documentation": "https://docs.juspay.in",
+    }

--- a/juspay_mcp/auth/middleware.py
+++ b/juspay_mcp/auth/middleware.py
@@ -1,0 +1,173 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""Bearer auth middleware.
+
+For any non-public path it requires `Authorization: Bearer <token>`, validates
+the token against Portal (with a short-lived LRU cache to avoid hammering the
+upstream), and pushes a PortalUserInfo onto a ContextVar so tool handlers can
+read it. On failure it returns a JSON-RPC `-32001` error with the
+`WWW-Authenticate` header demanded by RFC 9728 §5.1.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from .config import OAuthConfig
+from .context import OAuthRequestContext, PortalUserInfo, clear_current, set_current
+from .portal_client import PortalClient
+
+logger = logging.getLogger(__name__)
+
+# Paths that bypass the bearer check entirely. The MCP transport endpoints
+# themselves are NOT in this list — they require auth.
+_PUBLIC_PATH_PREFIXES = (
+    "/health",
+    "/.well-known/",
+    "/oauth/",
+)
+
+
+def _is_public_path(path: str) -> bool:
+    if path in ("/health", "/health/ready"):
+        return True
+    for prefix in _PUBLIC_PATH_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    # Per-mount well-known docs (e.g. /juspay-dashboard-stream/.well-known/...)
+    if "/.well-known/" in path:
+        return True
+    return False
+
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app,
+        cfg: OAuthConfig,
+        portal: PortalClient,
+        validation_cache: dict[str, tuple[PortalUserInfo, float]] | None = None,
+    ) -> None:
+        super().__init__(app)
+        self._cfg = cfg
+        self._portal = portal
+        # token -> (user_info, expiry_epoch). When `validation_cache` is passed
+        # in, the same dict is also shared with /oauth/revoke so that revoked
+        # tokens are evicted immediately instead of lingering until their TTL.
+        self._cache: dict[str, tuple[PortalUserInfo, float]] = (
+            validation_cache if validation_cache is not None else {}
+        )
+
+    async def _validate_with_cache(self, token: str) -> PortalUserInfo | None:
+        # Dev bypass: useful for curl-driven smoke tests so we don't need a
+        # real Portal token. The token value is configured via env and never
+        # rotates, so it must NEVER be set in production.
+        if self._cfg.dev_test_token and token == self._cfg.dev_test_token:
+            return PortalUserInfo(
+                merchant_id=self._cfg.dev_test_merchant_id,
+                user_id="dev-user",
+                email="dev@example.com",
+                context="MERCHANT",
+                username="dev",
+                tenant_account_id=None,
+                valid_host=None,
+            )
+
+        now = time.time()
+        cached = self._cache.get(token)
+        if cached is not None:
+            user_info, expiry = cached
+            if expiry > now:
+                return user_info
+            self._cache.pop(token, None)
+
+        user_info = await self._portal.validate(token)
+        if user_info is None:
+            return None
+        self._cache[token] = (user_info, now + self._cfg.validation_cache_ttl_seconds)
+        return user_info
+
+    def _challenge_header(self, request: Request, error: str | None = None) -> str:
+        # Per RFC 9728 §5.1 the WWW-Authenticate header must point to the
+        # resource_metadata URL. We use the per-mount path when present so the
+        # client can fall back to well-known probing if the header is dropped
+        # by an intermediary.
+        path = request.url.path
+        # Strip any trailing /messages or /stream suffix so we land on the
+        # mount-level well-known doc.
+        base = path.rsplit("/", 1)[0] if path.count("/") > 1 else ""
+        prm_url = f"{self._cfg.mcp_server_url}{base}/.well-known/oauth-protected-resource"
+        parts = [f'Bearer resource_metadata="{prm_url}"']
+        if self._cfg.scopes_supported:
+            parts.append(f'scope="{" ".join(self._cfg.scopes_supported)}"')
+        if error:
+            parts.append(f'error="{error}"')
+        return ", ".join(parts)
+
+    def _unauthorized(
+        self, request: Request, error: str | None = None, message: str = "Authentication required"
+    ) -> Response:
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "error": {"code": -32001, "message": message},
+                "id": None,
+            },
+            status_code=401,
+            headers={"WWW-Authenticate": self._challenge_header(request, error)},
+        )
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if _is_public_path(request.url.path):
+            return await call_next(request)
+
+        auth_header = request.headers.get("authorization") or request.headers.get("Authorization")
+        if not auth_header or not auth_header.lower().startswith("bearer "):
+            return self._unauthorized(request)
+
+        token = auth_header[7:].strip()
+        if not token:
+            return self._unauthorized(request, error="invalid_token")
+
+        user_info = await self._validate_with_cache(token)
+        if user_info is None:
+            return self._unauthorized(request, error="invalid_token", message="Invalid or expired token")
+
+        ctx = OAuthRequestContext(access_token=token, user_info=user_info)
+        set_current(ctx)
+        # Also stash on request.state so existing handlers can read it inline.
+        request.state.oauth_context = ctx
+        # Compatibility shim for the legacy ContextVar in juspay_mcp.tools:
+        # populate juspay_credentials with the Portal-issued token so existing
+        # handlers keep working without any modification. The dashboard mcp
+        # already expects `dashboard_token`; core expects `api_key` +
+        # `merchant_id`. We provide all three so both modes work.
+        request.state.juspay_credentials = {
+            "api_key": token,
+            "merchant_id": user_info.merchant_id,
+            "dashboard_token": token,
+            # Signals to the dashboard tool handlers (which have their own
+            # token-validation step) that this request is OAuth-sourced. They
+            # branch on this to hit /ec/v2/authorize instead of the legacy
+            # /api/ec/v1/validate/token endpoint. See
+            # juspay_dashboard_mcp/api/utils.py:get_juspay_host_from_api.
+            "auth_type": "oauth",
+        }
+
+        try:
+            return await call_next(request)
+        finally:
+            clear_current()

--- a/juspay_mcp/auth/pkce.py
+++ b/juspay_mcp/auth/pkce.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""PKCE S256 helpers (RFC 7636).
+
+We only support the S256 challenge method — the plain method is forbidden by
+OAuth 2.1 and the MCP authorization profile requires S256 when technically
+capable.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+
+def compute_s256_challenge(verifier: str) -> str:
+    """Compute the base64url(no-padding) SHA-256 of `verifier`."""
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def validate_s256(verifier: str, challenge: str) -> bool:
+    return compute_s256_challenge(verifier) == challenge

--- a/juspay_mcp/auth/portal_client.py
+++ b/juspay_mcp/auth/portal_client.py
@@ -1,0 +1,191 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""Thin async wrapper around the Juspay Portal OAuth endpoints.
+
+We use Portal as the upstream identity provider. The wire shapes (paths, body
+schema, `resource` query trick on /authorize) are taken from the
+juspay-genius/genius-mcp-app reference implementation so behaviour matches
+across both MCP servers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from .config import OAuthConfig
+from .context import PortalUserInfo
+
+logger = logging.getLogger(__name__)
+
+# Portal is byte-strict about this query string. It MUST be emitted exactly as:
+#     resource={%22COMMON%22%20%3A%20%22R%22}
+# with literal `{` `}` (not %7B / %7D) and `%20` for spaces (not `+`). Anything
+# else — including RFC-equivalent encodings — gets a 400. This matches the form
+# used by genius-mcp-app/main.ts:225 and by the working curl example Portal
+# documents. We pass the URL as a complete string to httpx (httpx preserves
+# query bytes when given a URL string) — passing via params= triggers httpx's
+# QueryParams encoder, which produces the wrong form.
+_PORTAL_VALIDATE_QUERY = "resource={%22COMMON%22%20%3A%20%22R%22}"
+
+
+@dataclass(frozen=True)
+class TokenResponse:
+    access_token: str
+    refresh_token: str | None
+    expires_in: int
+    token_type: str
+
+
+class PortalClient:
+    def __init__(self, cfg: OAuthConfig, http: httpx.AsyncClient | None = None) -> None:
+        self._cfg = cfg
+        self._http = http or httpx.AsyncClient(timeout=30.0)
+        self._owns_http = http is None
+
+    async def aclose(self) -> None:
+        if self._owns_http:
+            await self._http.aclose()
+
+    async def exchange_code(
+        self, client_id: str, client_secret: str, code: str
+    ) -> TokenResponse | None:
+        try:
+            resp = await self._http.post(
+                f"{self._cfg.portal_base_url}/ec/v2/token",
+                json={
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "action": "generate_token",
+                    "code": code,
+                },
+                headers={"Content-Type": "application/json"},
+            )
+        except httpx.HTTPError as e:
+            logger.error("portal token exchange failed: %s", e)
+            return None
+
+        if resp.status_code >= 400:
+            logger.error(
+                "portal token exchange returned %d: %s",
+                resp.status_code,
+                resp.text[:500],
+            )
+            return None
+
+        body = resp.json()
+        return TokenResponse(
+            access_token=body["access_token"],
+            refresh_token=body.get("refresh_token"),
+            expires_in=int(body.get("expires_in", 3600)),
+            token_type=body.get("token_type", "Bearer"),
+        )
+
+    async def refresh(
+        self, client_id: str, client_secret: str, refresh_token: str
+    ) -> TokenResponse | None:
+        try:
+            resp = await self._http.post(
+                f"{self._cfg.portal_base_url}/ec/v2/token",
+                json={
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "action": "refresh_token",
+                    "refresh_token": refresh_token,
+                },
+                headers={"Content-Type": "application/json"},
+            )
+        except httpx.HTTPError as e:
+            logger.error("portal refresh failed: %s", e)
+            return None
+
+        if resp.status_code >= 400:
+            logger.error(
+                "portal refresh returned %d: %s",
+                resp.status_code,
+                resp.text[:500],
+            )
+            return None
+
+        body = resp.json()
+        return TokenResponse(
+            access_token=body["access_token"],
+            refresh_token=body.get("refresh_token"),
+            expires_in=int(body.get("expires_in", 3600)),
+            token_type=body.get("token_type", "Bearer"),
+        )
+
+    async def revoke_token(self, client_id: str, token: str) -> bool:
+        """Tell Portal to invalidate the OAuth session backing this bearer.
+
+        Mirrors the dashboard's logout call:
+            DELETE /ec/v1/token/revoke/entity
+            Headers: Content-Type + x-web-logintoken (the bearer being revoked)
+            Body:    {"client_id": "...", "scope": "user_access"}
+
+        Best-effort: returns True on 2xx, False otherwise. The /oauth/revoke
+        endpoint must always reply 200 to its caller per RFC 7009 §2.2, even
+        if Portal rejects — so we just log on failure.
+        """
+        url = f"{self._cfg.portal_base_url}/ec/v1/token/revoke/entity"
+        headers = {
+            "Content-Type": "application/json",
+            "x-web-logintoken": token,
+        }
+        body = {"client_id": client_id, "scope": "user_access"}
+        try:
+            resp = await self._http.request(
+                "DELETE", url, json=body, headers=headers, timeout=10.0
+            )
+        except httpx.HTTPError as e:
+            logger.error("portal revoke failed: %s", e)
+            return False
+        if resp.status_code >= 400:
+            logger.warning(
+                "portal revoke returned %d: %s",
+                resp.status_code,
+                resp.text[:300],
+            )
+            return False
+        logger.info("portal revoke OK: %d", resp.status_code)
+        return True
+
+    async def validate(self, token: str) -> PortalUserInfo | None:
+        # Build the URL as a string so httpx preserves the query verbatim.
+        # See the comment on _PORTAL_VALIDATE_QUERY for why this matters.
+        url = f"{self._cfg.portal_base_url}/ec/v2/authorize?{_PORTAL_VALIDATE_QUERY}"
+        try:
+            resp = await self._http.get(
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        except httpx.HTTPError as e:
+            logger.error("portal validate failed: %s", e)
+            return None
+
+        if resp.status_code >= 400:
+            logger.warning(
+                "portal validate returned %d: %s",
+                resp.status_code,
+                resp.text[:300],
+            )
+            return None
+
+        body = resp.json()
+        # Portal returns camelCase. Be defensive: tolerate either case.
+        merchant_id = body.get("merchantId") or body.get("merchant_id") or ""
+        user_id = body.get("userId") or body.get("user_id") or ""
+        return PortalUserInfo(
+            merchant_id=str(merchant_id),
+            user_id=str(user_id),
+            email=body.get("email", ""),
+            context=body.get("context", "MERCHANT"),
+            username=body.get("username"),
+            tenant_account_id=body.get("tenantAccountId") or body.get("tenant_account_id"),
+            valid_host=body.get("validHost") or body.get("valid_host"),
+        )

--- a/juspay_mcp/auth/routes.py
+++ b/juspay_mcp/auth/routes.py
@@ -1,0 +1,367 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""Starlette routes for OAuth discovery + endpoints.
+
+Endpoint inventory (all mounted on the same Starlette app as the MCP transport
+endpoints):
+
+  GET  /.well-known/oauth-protected-resource
+  GET  /<mount>/.well-known/oauth-protected-resource     (per-mount alias)
+  GET  /.well-known/oauth-authorization-server
+  GET  /.well-known/openid-configuration                 (RFC 8414 alias)
+  GET  /.well-known/jwks.json
+  POST /oauth/register                                   (RFC 7591 DCR)
+  GET  /oauth/authorize
+  GET  /oauth/callback
+  POST /oauth/token
+  POST /oauth/revoke
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import secrets
+import time
+from urllib.parse import urlencode, urlparse
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.routing import Route
+
+from .config import OAuthConfig
+from .metadata import authorization_server_metadata, protected_resource_metadata
+from .pkce import validate_s256
+from .portal_client import PortalClient
+from .state_store import MemoryStateStore, StateData
+
+logger = logging.getLogger(__name__)
+
+
+def _bad_request(error: str, description: str) -> JSONResponse:
+    return JSONResponse(
+        {"error": error, "error_description": description}, status_code=400
+    )
+
+
+def _unauthorized_client(description: str) -> JSONResponse:
+    return JSONResponse(
+        {"error": "invalid_client", "error_description": description}, status_code=401
+    )
+
+
+def _parse_client_credentials(request: Request, body: dict) -> tuple[str | None, str | None]:
+    """Pull client_id / client_secret from either the body or a Basic auth header."""
+    client_id = body.get("client_id")
+    client_secret = body.get("client_secret")
+
+    auth_header = request.headers.get("authorization") or request.headers.get("Authorization")
+    if auth_header and auth_header.lower().startswith("basic "):
+        try:
+            decoded = base64.b64decode(auth_header[6:].encode("ascii")).decode("utf-8")
+            cid, csec = decoded.split(":", 1)
+            client_id = cid or client_id
+            client_secret = csec or client_secret
+        except Exception:
+            logger.warning("invalid Basic auth header on token endpoint")
+
+    return client_id, client_secret
+
+
+async def _read_form_or_json(request: Request) -> dict:
+    """Token endpoint accepts both x-www-form-urlencoded and JSON."""
+    content_type = (request.headers.get("content-type") or "").lower()
+    if "application/x-www-form-urlencoded" in content_type:
+        form = await request.form()
+        return {k: form[k] for k in form.keys()}
+    if "application/json" in content_type:
+        try:
+            return await request.json()
+        except Exception:
+            return {}
+    # Fall back to form, then JSON.
+    try:
+        form = await request.form()
+        if form:
+            return {k: form[k] for k in form.keys()}
+    except Exception:
+        pass
+    try:
+        return await request.json()
+    except Exception:
+        return {}
+
+
+def _resource_is_acceptable(cfg: OAuthConfig, resource: str | None) -> bool:
+    if not resource:
+        # Per spec we SHOULD require resource, but during DCR-only smoke tests
+        # some clients omit it. Accept None for now and tighten in phase 2.
+        return True
+    try:
+        parsed = urlparse(resource)
+    except Exception:
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    issuer_host = urlparse(cfg.mcp_server_url).netloc
+    return parsed.netloc == issuer_host or parsed.netloc in cfg.extra_resource_hostnames
+
+
+# ---- Handlers ----------------------------------------------------------------
+
+
+def build_routes(
+    cfg: OAuthConfig,
+    portal: PortalClient,
+    store: MemoryStateStore,
+    validation_cache: dict | None = None,
+) -> list[Route]:
+    """Construct the OAuth/discovery route list.
+
+    `validation_cache` (optional) is the same dict shared with
+    `BearerAuthMiddleware`. When provided, the `/oauth/revoke` handler evicts
+    revoked bearers from it so the next request can't sneak past the cache
+    TTL window.
+    """
+
+    # ---------- well-known ----------------------------------------------------
+    async def prm_root(_: Request) -> Response:
+        return JSONResponse(protected_resource_metadata(cfg))
+
+    async def prm_for_mount(request: Request) -> Response:
+        # `mount_path` arrives via path templating, e.g. /juspay-dashboard-stream
+        mount = request.path_params["mount"]
+        resource_url = f"{cfg.mcp_server_url}/{mount}"
+        return JSONResponse(protected_resource_metadata(cfg, resource_url=resource_url))
+
+    async def asm(_: Request) -> Response:
+        return JSONResponse(authorization_server_metadata(cfg))
+
+    async def jwks(_: Request) -> Response:
+        return JSONResponse({"keys": []})
+
+    # ---------- RFC 7591 dynamic client registration --------------------------
+    async def register(request: Request) -> Response:
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+
+        client_id = body.get("client_id") or cfg.upstream_client_id or f"client_{int(time.time())}"
+        client_secret = (
+            body.get("client_secret") or cfg.upstream_client_secret or secrets.token_hex(32)
+        )
+        return JSONResponse(
+            {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "client_id_issued_at": int(time.time()),
+                "client_secret_expires_at": 0,
+                "redirect_uris": body.get("redirect_uris", []),
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "client_secret_post",
+                "client_name": body.get("client_name", "MCP Client"),
+            }
+        )
+
+    # ---------- /oauth/authorize ---------------------------------------------
+    async def authorize(request: Request) -> Response:
+        q = request.query_params
+        redirect_uri = q.get("redirect_uri")
+        state = q.get("state")
+        code_challenge = q.get("code_challenge")
+        code_challenge_method = q.get("code_challenge_method")
+        scope = q.get("scope")
+        client_id = q.get("client_id")
+        resource = q.get("resource")
+
+        if not redirect_uri:
+            return _bad_request("invalid_request", "redirect_uri is required")
+        if not state:
+            return _bad_request("invalid_request", "state is required")
+        if code_challenge and code_challenge_method and code_challenge_method != "S256":
+            return _bad_request(
+                "invalid_request",
+                "Only S256 PKCE challenge method is supported",
+            )
+        if not _resource_is_acceptable(cfg, resource):
+            return _bad_request("invalid_target", f"resource {resource!r} is not served by this server")
+
+        await store.put_state(
+            state,
+            StateData(
+                redirect_uri=redirect_uri,
+                client_id=client_id,
+                scope=scope,
+                resource=resource,
+                code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method,
+                created_at=time.time(),
+            ),
+        )
+
+        # Redirect the user-agent to Portal SSO. Portal will eventually
+        # redirect back to /oauth/callback on THIS server, which then bounces
+        # to the client-supplied redirect_uri.
+        portal_params = {
+            "client_id": client_id or cfg.upstream_client_id,
+            "redirect_uri": f"{cfg.mcp_server_url}/oauth/callback",
+            "scope": "user_access",
+            "state": state,
+        }
+        portal_url = f"{cfg.portal_base_url}?{urlencode(portal_params)}"
+        return RedirectResponse(portal_url, status_code=302)
+
+    # ---------- /oauth/callback ----------------------------------------------
+    async def callback(request: Request) -> Response:
+        q = request.query_params
+        code = q.get("code")
+        state = q.get("state")
+        error = q.get("error")
+        error_description = q.get("error_description")
+
+        if not state:
+            return _bad_request("invalid_request", "state is required")
+
+        state_data = await store.get_state(state)
+        if state_data is None:
+            return _bad_request("invalid_request", "Invalid or expired state")
+
+        target = state_data.redirect_uri
+        params: dict[str, str] = {"state": state}
+        if error:
+            params["error"] = error
+            if error_description:
+                params["error_description"] = error_description
+            await store.delete_state(state)
+        elif code:
+            params["code"] = code
+            await store.bind_code(code, state)
+        else:
+            return _bad_request("invalid_request", "Missing both code and error in callback")
+
+        sep = "&" if "?" in target else "?"
+        return RedirectResponse(f"{target}{sep}{urlencode(params)}", status_code=302)
+
+    # ---------- /oauth/token --------------------------------------------------
+    async def token(request: Request) -> Response:
+        body = await _read_form_or_json(request)
+        grant_type = body.get("grant_type")
+        client_id, client_secret = _parse_client_credentials(request, body)
+
+        if not client_id or not client_secret:
+            # Fall back to the server-side configured upstream client. This
+            # makes the flow work for Claude Code's "none" auth method clients
+            # that registered via DCR without persisting a real secret.
+            client_id = client_id or cfg.upstream_client_id
+            client_secret = client_secret or cfg.upstream_client_secret
+
+        if not client_id or not client_secret:
+            return _unauthorized_client("Client credentials required")
+
+        if grant_type == "authorization_code":
+            code = body.get("code")
+            code_verifier = body.get("code_verifier")
+            if not code:
+                return _bad_request("invalid_request", "Missing authorization code")
+
+            bound_state = await store.lookup_state_by_code(code)
+            state_data = await store.get_state(bound_state) if bound_state else None
+
+            if state_data and state_data.code_challenge:
+                if not code_verifier:
+                    return _bad_request("invalid_request", "code_verifier is required for PKCE")
+                if not validate_s256(code_verifier, state_data.code_challenge):
+                    return _bad_request("invalid_grant", "Invalid code_verifier")
+
+            token_resp = await portal.exchange_code(client_id, client_secret, code)
+            if token_resp is None:
+                return _bad_request("invalid_grant", "Portal token exchange failed")
+
+            if bound_state:
+                await store.delete_state(bound_state)
+                await store.delete_code(code)
+
+            return JSONResponse(
+                {
+                    "access_token": token_resp.access_token,
+                    "refresh_token": token_resp.refresh_token,
+                    "expires_in": token_resp.expires_in,
+                    "token_type": "Bearer",
+                    "scope": " ".join(cfg.scopes_supported),
+                }
+            )
+
+        if grant_type == "refresh_token":
+            refresh_token = body.get("refresh_token")
+            if not refresh_token:
+                return _bad_request("invalid_request", "Missing refresh_token")
+            token_resp = await portal.refresh(client_id, client_secret, refresh_token)
+            if token_resp is None:
+                return _bad_request("invalid_grant", "Portal refresh failed")
+            return JSONResponse(
+                {
+                    "access_token": token_resp.access_token,
+                    "refresh_token": token_resp.refresh_token,
+                    "expires_in": token_resp.expires_in,
+                    "token_type": "Bearer",
+                    "scope": " ".join(cfg.scopes_supported),
+                }
+            )
+
+        return _bad_request(
+            "unsupported_grant_type", f"Grant type {grant_type!r} is not supported"
+        )
+
+    # ---------- /oauth/revoke -------------------------------------------------
+    async def revoke(request: Request) -> Response:
+        """RFC 7009 revocation endpoint.
+
+        Forwards to Portal's session-revoke API so the OAuth grant is
+        actually invalidated upstream (powers Claude Code's `/mcp` →
+        "Clear authentication" and re-auth flows). Always returns 200 per
+        RFC 7009 §2.2, even when Portal fails or the token is unknown —
+        the response body is informational only.
+        """
+        body = await _read_form_or_json(request)
+        token = body.get("token")
+        # token_type_hint can be 'access_token' | 'refresh_token' per RFC 7009.
+        # Portal revokes the whole entity (user session) regardless so we
+        # don't need to differentiate.
+        client_id, _client_secret = _parse_client_credentials(request, body)
+        client_id = client_id or cfg.upstream_client_id
+
+        revoked = False
+        if token and client_id:
+            revoked = await portal.revoke_token(client_id, token)
+            # Evict the validated-token cache so subsequent requests are forced
+            # to re-validate via Portal (which will now return 4xx).
+            if validation_cache is not None:
+                validation_cache.pop(token, None)
+        elif not token:
+            logger.warning("/oauth/revoke called without a `token` body field")
+
+        return JSONResponse({"revoked": revoked})
+
+    # ---------- assemble ------------------------------------------------------
+    routes: list[Route] = [
+        Route("/.well-known/oauth-protected-resource", endpoint=prm_root, methods=["GET"]),
+        Route(
+            "/{mount:str}/.well-known/oauth-protected-resource",
+            endpoint=prm_for_mount,
+            methods=["GET"],
+        ),
+        Route("/.well-known/oauth-authorization-server", endpoint=asm, methods=["GET"]),
+        Route("/.well-known/openid-configuration", endpoint=asm, methods=["GET"]),
+        Route("/.well-known/jwks.json", endpoint=jwks, methods=["GET"]),
+        Route("/oauth/register", endpoint=register, methods=["POST"]),
+        Route("/oauth/authorize", endpoint=authorize, methods=["GET"]),
+        Route("/oauth/callback", endpoint=callback, methods=["GET"]),
+        Route("/oauth/token", endpoint=token, methods=["POST"]),
+        Route("/oauth/revoke", endpoint=revoke, methods=["POST"]),
+    ]
+    return routes

--- a/juspay_mcp/auth/state_store.py
+++ b/juspay_mcp/auth/state_store.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+"""TTL'd in-memory store for OAuth `state` and authorization `code` rows.
+
+This is good enough for single-process deployments and dev. Swap in a Redis
+backend later by implementing the same interface (`StateStore`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class StateData:
+    redirect_uri: str
+    client_id: str | None
+    scope: str | None
+    resource: str | None
+    code_challenge: str | None
+    code_challenge_method: str | None
+    created_at: float
+
+
+class StateStore(Protocol):
+    async def put_state(self, state: str, data: StateData) -> None: ...
+    async def get_state(self, state: str) -> StateData | None: ...
+    async def delete_state(self, state: str) -> None: ...
+    async def bind_code(self, code: str, state: str) -> None: ...
+    async def lookup_state_by_code(self, code: str) -> str | None: ...
+    async def delete_code(self, code: str) -> None: ...
+
+
+class MemoryStateStore:
+    def __init__(self, ttl_seconds: int = 600) -> None:
+        self._ttl = ttl_seconds
+        self._states: dict[str, StateData] = {}
+        self._code_to_state: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+        self._sweeper_task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        if self._sweeper_task is None:
+            self._sweeper_task = asyncio.create_task(self._sweep_loop())
+
+    async def stop(self) -> None:
+        if self._sweeper_task is not None:
+            self._sweeper_task.cancel()
+            try:
+                await self._sweeper_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._sweeper_task = None
+
+    async def _sweep_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(60)
+                await self._sweep()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                continue
+
+    async def _sweep(self) -> None:
+        now = time.time()
+        async with self._lock:
+            expired = [s for s, d in self._states.items() if now - d.created_at > self._ttl]
+            for s in expired:
+                self._states.pop(s, None)
+            orphan_codes = [c for c, s in self._code_to_state.items() if s not in self._states]
+            for c in orphan_codes:
+                self._code_to_state.pop(c, None)
+
+    async def put_state(self, state: str, data: StateData) -> None:
+        async with self._lock:
+            self._states[state] = data
+
+    async def get_state(self, state: str) -> StateData | None:
+        async with self._lock:
+            data = self._states.get(state)
+            if data is None:
+                return None
+            if time.time() - data.created_at > self._ttl:
+                self._states.pop(state, None)
+                return None
+            return data
+
+    async def delete_state(self, state: str) -> None:
+        async with self._lock:
+            self._states.pop(state, None)
+
+    async def bind_code(self, code: str, state: str) -> None:
+        async with self._lock:
+            self._code_to_state[code] = state
+
+    async def lookup_state_by_code(self, code: str) -> str | None:
+        async with self._lock:
+            return self._code_to_state.get(code)
+
+    async def delete_code(self, code: str) -> None:
+        async with self._lock:
+            self._code_to_state.pop(code, None)

--- a/juspay_mcp/main.py
+++ b/juspay_mcp/main.py
@@ -12,6 +12,10 @@ import asyncio
 import logging
 import contextlib
 
+# Load .env BEFORE any os.getenv() so JUSPAY_MCP_TYPE / OAUTH_ENABLED etc.
+# from the env file participate in the import-time branching below.
+dotenv.load_dotenv()
+
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
 from starlette.responses import JSONResponse, Response
@@ -21,6 +25,12 @@ from starlette.requests import Request
 
 from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+from juspay_mcp.auth import config as auth_config
+from juspay_mcp.auth.middleware import BearerAuthMiddleware
+from juspay_mcp.auth.portal_client import PortalClient
+from juspay_mcp.auth.routes import build_routes as build_oauth_routes
+from juspay_mcp.auth.state_store import MemoryStateStore
 
 # Determine which MCP app to use based on JUSPAY_MCP_TYPE
 JUSPAY_MCP_TYPE = os.getenv("JUSPAY_MCP_TYPE", "").upper()
@@ -46,9 +56,6 @@ else:
     MCP_APPS["default"] = default_app
 
 from juspay_mcp.stdio import run_stdio
-
-# Load environment variables.
-dotenv.load_dotenv()
 
 # Configure logging.
 logging.basicConfig(
@@ -121,9 +128,22 @@ def main(host: str, port: int, mode: str):
         sse_endpoint_path = "/juspay"
         streamable_endpoint_path = "/juspay-stream"
     
-    logger.info("Running with header-based authentication")
-    logger.info("Expected headers: JUSPAY_API_KEY, JUSPAY_MERCHANT_ID, JUSPAY_WEB_LOGIN_TOKEN")
-    
+    oauth_cfg = auth_config.load()
+    portal_client = None
+    oauth_state_store = None
+    oauth_routes_list: list = []
+    oauth_validation_cache: dict = {}
+    if oauth_cfg.enabled:
+        portal_client = PortalClient(oauth_cfg)
+        oauth_state_store = MemoryStateStore(ttl_seconds=oauth_cfg.state_ttl_seconds)
+        oauth_routes_list = build_oauth_routes(
+            oauth_cfg, portal_client, oauth_state_store, validation_cache=oauth_validation_cache
+        )
+        logger.info("Running with OAuth bearer authentication")
+    else:
+        logger.info("Running with header-based authentication")
+        logger.info("Expected headers: JUSPAY_API_KEY, JUSPAY_MERCHANT_ID, JUSPAY_WEB_LOGIN_TOKEN")
+
     sse_transport_handler = SseServerTransport(message_endpoint_path)
 
     async def health_check(request: Request):
@@ -228,6 +248,11 @@ def main(host: str, port: int, mode: str):
         Mount(message_endpoint_path, app=sse_transport_handler.handle_post_message),
     ]
 
+    # Prepend OAuth discovery + /oauth/* routes before the MCP transport
+    # routes so they win the longest-prefix match.
+    if oauth_routes_list:
+        routes = oauth_routes_list + routes
+
     if JUSPAY_MCP_TYPE == "DASHBOARD":
         # Dashboard MCP
         dashboard_sse_handler = make_sse_handler("dashboard")
@@ -285,8 +310,17 @@ def main(host: str, port: int, mode: str):
                 if docs_v2_session_mgr is not None:
                     await stack.enter_async_context(docs_v2_session_mgr.run())
                     logger.info("Docs v2 StreamableHTTP session manager started")
+                if oauth_state_store is not None:
+                    await oauth_state_store.start()
+                    logger.info("OAuth state store sweeper started")
                 logger.info("All StreamableHTTP session managers started successfully")
-                yield
+                try:
+                    yield
+                finally:
+                    if oauth_state_store is not None:
+                        await oauth_state_store.stop()
+                    if portal_client is not None:
+                        await portal_client.aclose()
             logger.info("StreamableHTTP session managers stopped")
 
     else:
@@ -309,13 +343,32 @@ def main(host: str, port: int, mode: str):
             """Application lifespan context manager for single MCP app."""
             async with default_session_mgr.run():
                 logger.info("StreamableHTTP session manager started successfully")
-                yield
+                if oauth_state_store is not None:
+                    await oauth_state_store.start()
+                    logger.info("OAuth state store sweeper started")
+                try:
+                    yield
+                finally:
+                    if oauth_state_store is not None:
+                        await oauth_state_store.stop()
+                    if portal_client is not None:
+                        await portal_client.aclose()
             logger.info("StreamableHTTP session manager stopped")
 
-    # Add header authentication middleware
-    middleware = [
-        Middleware(JuspayHeaderAuthMiddleware),
-    ]
+    # Authentication middleware — OAuth bearer when enabled, else legacy header path.
+    if oauth_cfg.enabled and portal_client is not None:
+        middleware = [
+            Middleware(
+                BearerAuthMiddleware,
+                cfg=oauth_cfg,
+                portal=portal_client,
+                validation_cache=oauth_validation_cache,
+            ),
+        ]
+    else:
+        middleware = [
+            Middleware(JuspayHeaderAuthMiddleware),
+        ]
 
     starlette_app = Starlette(
         debug=False,
@@ -338,6 +391,16 @@ def main(host: str, port: int, mode: str):
         logger.info("Starting MCP server on:")
         logger.info(f"  SSE endpoint:                  http://{host}:{port}{sse_endpoint_path}")
         logger.info(f"  StreamableHTTP endpoint:       http://{host}:{port}{streamable_endpoint_path}")
+
+    if oauth_cfg.enabled:
+        logger.info("OAuth discovery + endpoints:")
+        logger.info(f"  Issuer (MCP_SERVER_URL):       {oauth_cfg.mcp_server_url}")
+        logger.info(f"  Protected-resource metadata:   {oauth_cfg.mcp_server_url}/.well-known/oauth-protected-resource")
+        logger.info(f"  Authorization-server metadata: {oauth_cfg.mcp_server_url}/.well-known/oauth-authorization-server")
+        logger.info(f"  Dynamic client registration:   {oauth_cfg.mcp_server_url}/oauth/register")
+        logger.info(f"  Authorize:                     {oauth_cfg.mcp_server_url}/oauth/authorize")
+        logger.info(f"  Token:                         {oauth_cfg.mcp_server_url}/oauth/token")
+        logger.info(f"  Portal IdP:                    {oauth_cfg.portal_base_url}")
 
     uvicorn.run(starlette_app, host=host, port=port, lifespan="on")
 

--- a/tools_test/smoke_legacy_off.py
+++ b/tools_test/smoke_legacy_off.py
@@ -1,0 +1,38 @@
+"""Verify that with OAUTH_ENABLED=false (the default), the OAuth subsystem is
+inert: no /.well-known routes are exposed by the auth package and no Bearer
+middleware is installed. The legacy JuspayHeaderAuthMiddleware path stays.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure flag is off
+os.environ.pop("OAUTH_ENABLED", None)
+
+from juspay_mcp.auth import config as auth_config
+
+cfg = auth_config.load()
+if cfg.enabled:
+    print("[FAIL] config.enabled True when OAUTH_ENABLED unset")
+    sys.exit(1)
+print("[OK] OAUTH_ENABLED unset -> config.enabled is False")
+
+# Toggle false explicitly
+os.environ["OAUTH_ENABLED"] = "false"
+cfg2 = auth_config.load()
+if cfg2.enabled:
+    print("[FAIL] OAUTH_ENABLED=false still enabled")
+    sys.exit(1)
+print("[OK] OAUTH_ENABLED=false -> config.enabled is False")
+
+# Toggle true to make sure the flag works in the opposite direction too
+os.environ["OAUTH_ENABLED"] = "true"
+cfg3 = auth_config.load()
+if not cfg3.enabled:
+    print("[FAIL] OAUTH_ENABLED=true did not enable")
+    sys.exit(1)
+print("[OK] OAUTH_ENABLED=true -> config.enabled is True")
+
+print("[OK] feature flag honoured in both directions")

--- a/tools_test/smoke_oauth.py
+++ b/tools_test/smoke_oauth.py
@@ -1,0 +1,220 @@
+"""Smoke test the OAuth discovery + bearer flow without binding to a socket.
+
+We build the Starlette app via the same routes/middleware used in main(), then
+talk to it through `httpx.AsyncClient(transport=ASGITransport(app=...))`.
+That sidesteps any process-network-namespace quirks in this sandbox while
+still exercising the real middleware + routes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+# Force OAuth on before importing main, since flags are read at import/load.
+os.environ["OAUTH_ENABLED"] = "true"
+os.environ["JUSPAY_MCP_TYPE"] = "DASHBOARD"
+os.environ.setdefault("MCP_SERVER_URL", "http://localhost:8080")
+os.environ.setdefault("PORTAL_BASE_URL", "https://portal.juspay.in")
+os.environ.setdefault("OAUTH_CLIENT_ID", "test-client")
+os.environ.setdefault("OAUTH_CLIENT_SECRET", "test-secret")
+os.environ.setdefault("OAUTH_DEV_TEST_TOKEN", "test-bearer-123")
+
+import httpx
+from httpx import ASGITransport
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.routing import Mount, Route
+
+from juspay_mcp.auth import config as auth_config
+from juspay_mcp.auth.middleware import BearerAuthMiddleware
+from juspay_mcp.auth.portal_client import PortalClient
+from juspay_mcp.auth.routes import build_routes as build_oauth_routes
+from juspay_mcp.auth.state_store import MemoryStateStore
+
+
+async def health(_request):
+    from starlette.responses import JSONResponse
+    return JSONResponse({"status": "ok"})
+
+
+async def fake_dashboard_endpoint(request):
+    """Stand-in for the real streamable-HTTP MCP endpoint.
+
+    The point of this smoke test is to verify the auth middleware + routes —
+    not the MCP transport — so this just echoes back whether auth succeeded.
+    """
+    from starlette.responses import JSONResponse
+    ctx = getattr(request.state, "oauth_context", None)
+    return JSONResponse(
+        {
+            "authenticated": ctx is not None,
+            "merchant_id": ctx.user_info.merchant_id if ctx else None,
+        }
+    )
+
+
+def build_app():
+    cfg = auth_config.load()
+    assert cfg.enabled, "OAuth must be enabled for the smoke test"
+    portal = PortalClient(cfg)
+    store = MemoryStateStore(ttl_seconds=cfg.state_ttl_seconds)
+
+    routes = build_oauth_routes(cfg, portal, store) + [
+        Route("/health", endpoint=health, methods=["GET"]),
+        Route(
+            "/juspay-dashboard-stream",
+            endpoint=fake_dashboard_endpoint,
+            methods=["GET", "POST", "DELETE"],
+        ),
+    ]
+    middleware = [Middleware(BearerAuthMiddleware, cfg=cfg, portal=portal)]
+    app = Starlette(routes=routes, middleware=middleware)
+    return app
+
+
+PASS = "[OK]"
+FAIL = "[FAIL]"
+
+
+def check(label, cond, detail=""):
+    print(f"{PASS if cond else FAIL} {label}" + (f"  — {detail}" if detail else ""))
+    if not cond:
+        check.failures += 1
+check.failures = 0
+
+
+async def run():
+    app = build_app()
+    async with httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://localhost:8080") as c:
+        # 1. PRM root
+        r = await c.get("/.well-known/oauth-protected-resource")
+        check("PRM root 200", r.status_code == 200)
+        prm = r.json()
+        check("PRM has resource", "resource" in prm, prm.get("resource"))
+        check("PRM has authorization_servers", "authorization_servers" in prm and prm["authorization_servers"], prm.get("authorization_servers"))
+        check("PRM scopes_supported populated", isinstance(prm.get("scopes_supported"), list) and len(prm["scopes_supported"]) > 0)
+
+        # 2. PRM per-mount
+        r = await c.get("/juspay-dashboard-stream/.well-known/oauth-protected-resource")
+        check("PRM per-mount 200", r.status_code == 200)
+        prm_mount = r.json()
+        check(
+            "PRM per-mount resource matches",
+            prm_mount.get("resource") == "http://localhost:8080/juspay-dashboard-stream",
+            prm_mount.get("resource"),
+        )
+
+        # 3. AS metadata
+        r = await c.get("/.well-known/oauth-authorization-server")
+        check("ASM 200", r.status_code == 200)
+        asm = r.json()
+        for field in [
+            "issuer",
+            "authorization_endpoint",
+            "token_endpoint",
+            "registration_endpoint",
+            "code_challenge_methods_supported",
+            "grant_types_supported",
+        ]:
+            check(f"ASM has {field}", field in asm, asm.get(field))
+        check("ASM advertises S256", "S256" in (asm.get("code_challenge_methods_supported") or []))
+
+        # 4. OIDC alias matches ASM
+        r2 = await c.get("/.well-known/openid-configuration")
+        check("OIDC alias 200", r2.status_code == 200)
+        check("OIDC alias body == ASM body", r2.json() == asm)
+
+        # 5. JWKS
+        r = await c.get("/.well-known/jwks.json")
+        check("JWKS 200 + keys=[]", r.status_code == 200 and r.json() == {"keys": []})
+
+        # 6. DCR
+        r = await c.post(
+            "/oauth/register",
+            json={"client_name": "Claude Code", "redirect_uris": ["http://localhost:33418/callback"]},
+        )
+        check("DCR 200", r.status_code == 200)
+        dcr = r.json()
+        for field in ["client_id", "client_secret", "grant_types", "redirect_uris"]:
+            check(f"DCR has {field}", field in dcr)
+
+        # 7. Unauth 401 on MCP endpoint
+        r = await c.post(
+            "/juspay-dashboard-stream",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        check("Unauth -> 401", r.status_code == 401)
+        wwa = r.headers.get("www-authenticate", "")
+        check("WWW-Authenticate present", wwa.startswith("Bearer"))
+        check("WWW-Authenticate includes resource_metadata", "resource_metadata=" in wwa, wwa)
+        body = r.json()
+        check("401 body is JSON-RPC", body.get("jsonrpc") == "2.0" and body.get("error", {}).get("code") == -32001)
+
+        # 8. Auth with dev test token
+        r = await c.post(
+            "/juspay-dashboard-stream",
+            headers={"Authorization": "Bearer test-bearer-123"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        check("Auth dev-token -> 200", r.status_code == 200, r.text)
+        check("Authenticated body shows merchant", r.json().get("merchant_id") == "TEST_MERCHANT", r.text)
+
+        # 9. Authorize redirect to Portal
+        r = await c.get(
+            "/oauth/authorize",
+            params={
+                "client_id": "test-client",
+                "redirect_uri": "http://localhost:33418/callback",
+                "state": "abc123",
+                "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                "code_challenge_method": "S256",
+                "resource": "http://localhost:8080/juspay-dashboard-stream",
+                "scope": "dashboard:read",
+            },
+            follow_redirects=False,
+        )
+        check("Authorize -> 302", r.status_code == 302, str(r.status_code))
+        check(
+            "Authorize -> Portal host",
+            r.headers.get("location", "").startswith("https://portal.juspay.in"),
+            r.headers.get("location"),
+        )
+
+        # 10. Unsupported grant
+        r = await c.post(
+            "/oauth/token",
+            data={"grant_type": "client_credentials", "client_id": "x", "client_secret": "y"},
+        )
+        check("Unsupported grant -> 400", r.status_code == 400)
+        check("Unsupported grant error", r.json().get("error") == "unsupported_grant_type")
+
+        # 11. PKCE rejection — simulate code <-> state binding manually and post bad verifier
+        from juspay_mcp.auth.state_store import StateData
+        from juspay_mcp.auth.routes import build_routes as _br  # noqa
+        # Pull store back from app: easier just to call /authorize first then /callback path.
+        # Recreate state directly through internal API to avoid Portal dependency.
+        # We need the same store instance the app uses → easier route: post a new authorize then
+        # have our test code bind the code locally. Simpler: skip — the unsupported_grant_type
+        # check + PKCE unit test (already passed earlier vs RFC vector) is sufficient.
+
+        # 12. revoke — always 200 per RFC 7009 §2.2 even when Portal rejects
+        # the fake token. We don't assert the body's `revoked` flag here
+        # because that depends on Portal reachability; the integration test
+        # with a stubbed PortalClient (smoke_oauth_flow.py) covers the happy
+        # path + cache eviction.
+        r = await c.post("/oauth/revoke", json={"token": "x"})
+        check("Revoke 200", r.status_code == 200, r.text)
+
+    print()
+    if check.failures:
+        print(f"{FAIL} {check.failures} assertion(s) failed")
+        sys.exit(1)
+    else:
+        print(f"{PASS} all checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/tools_test/smoke_oauth_flow.py
+++ b/tools_test/smoke_oauth_flow.py
@@ -1,0 +1,315 @@
+"""End-to-end OAuth flow including PKCE round-trip with a stubbed Portal.
+
+Stubs out PortalClient.exchange_code / refresh / validate so we can assert the
+full authorize -> callback -> token -> authed-mcp path without touching the
+real Portal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+os.environ["OAUTH_ENABLED"] = "true"
+os.environ["JUSPAY_MCP_TYPE"] = "DASHBOARD"
+os.environ.setdefault("MCP_SERVER_URL", "http://localhost:8080")
+os.environ.setdefault("PORTAL_BASE_URL", "https://portal.juspay.in")
+os.environ.setdefault("OAUTH_CLIENT_ID", "test-client")
+os.environ.setdefault("OAUTH_CLIENT_SECRET", "test-secret")
+
+import httpx
+from httpx import ASGITransport
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.routing import Route
+
+from juspay_mcp.auth import config as auth_config
+from juspay_mcp.auth.context import PortalUserInfo
+from juspay_mcp.auth.middleware import BearerAuthMiddleware
+from juspay_mcp.auth.portal_client import PortalClient, TokenResponse
+from juspay_mcp.auth.routes import build_routes
+from juspay_mcp.auth.state_store import MemoryStateStore
+
+
+CODE_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+CODE_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+ISSUED_TOKEN = "portal-access-token-xyz"
+ISSUED_REFRESH = "portal-refresh-token-xyz"
+
+
+class StubPortal:
+    """Replaces PortalClient methods used by routes/middleware."""
+
+    def __init__(self):
+        self.exchange_calls = 0
+        self.refresh_calls = 0
+        self.validate_calls = 0
+        self.revoke_calls: list[tuple[str, str]] = []
+        # When set, validate() returns None for `revoked_tokens` to simulate
+        # Portal rejecting the revoked bearer on subsequent re-validation.
+        self.revoked_tokens: set[str] = set()
+
+    async def exchange_code(self, client_id, client_secret, code):
+        self.exchange_calls += 1
+        return TokenResponse(
+            access_token=ISSUED_TOKEN,
+            refresh_token=ISSUED_REFRESH,
+            expires_in=3600,
+            token_type="Bearer",
+        )
+
+    async def refresh(self, client_id, client_secret, refresh_token):
+        self.refresh_calls += 1
+        return TokenResponse(
+            access_token="portal-access-token-NEW",
+            refresh_token="portal-refresh-token-NEW",
+            expires_in=3600,
+            token_type="Bearer",
+        )
+
+    async def validate(self, token):
+        self.validate_calls += 1
+        if token in self.revoked_tokens:
+            return None
+        if token == ISSUED_TOKEN or token == "portal-access-token-NEW":
+            return PortalUserInfo(
+                merchant_id="STUB_MERCHANT",
+                user_id="42",
+                email="t@example.com",
+                context="MERCHANT",
+                username="t",
+                tenant_account_id=None,
+                valid_host="portal.juspay.in",
+            )
+        return None
+
+    async def revoke_token(self, client_id, token):
+        self.revoke_calls.append((client_id, token))
+        self.revoked_tokens.add(token)
+        return True
+
+    async def aclose(self):
+        pass
+
+
+async def fake_dashboard(request):
+    from starlette.responses import JSONResponse
+    ctx = getattr(request.state, "oauth_context", None)
+    return JSONResponse({"merchant_id": ctx.user_info.merchant_id if ctx else None})
+
+
+PASS = "[OK]"
+FAIL = "[FAIL]"
+failures = 0
+
+
+def check(label, cond, detail=""):
+    global failures
+    print(f"{PASS if cond else FAIL} {label}" + (f"  — {detail}" if detail else ""))
+    if not cond:
+        failures += 1
+
+
+async def run():
+    cfg = auth_config.load()
+    stub = StubPortal()
+    store = MemoryStateStore(ttl_seconds=cfg.state_ttl_seconds)
+    validation_cache: dict = {}
+
+    routes = build_routes(cfg, stub, store, validation_cache=validation_cache) + [
+        Route(
+            "/juspay-dashboard-stream",
+            endpoint=fake_dashboard,
+            methods=["GET", "POST", "DELETE"],
+        ),
+    ]
+    middleware = [
+        Middleware(
+            BearerAuthMiddleware,
+            cfg=cfg,
+            portal=stub,
+            validation_cache=validation_cache,
+        )
+    ]
+    app = Starlette(routes=routes, middleware=middleware)
+
+    async with httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://localhost:8080") as c:
+        # 1. /authorize stores state + PKCE
+        state = "state-abc"
+        r = await c.get(
+            "/oauth/authorize",
+            params={
+                "client_id": "test-client",
+                "redirect_uri": "http://localhost:33418/callback",
+                "state": state,
+                "code_challenge": CODE_CHALLENGE,
+                "code_challenge_method": "S256",
+                "resource": "http://localhost:8080/juspay-dashboard-stream",
+            },
+            follow_redirects=False,
+        )
+        check("authorize -> 302 portal", r.status_code == 302)
+
+        # Verify state was persisted
+        sd = await store.get_state(state)
+        check("state persisted with PKCE", sd is not None and sd.code_challenge == CODE_CHALLENGE)
+
+        # 2. /callback with code -> 302 back to client redirect_uri
+        portal_code = "portal-auth-code-xxx"
+        r = await c.get(
+            "/oauth/callback",
+            params={"code": portal_code, "state": state},
+            follow_redirects=False,
+        )
+        check("callback -> 302", r.status_code == 302)
+        loc = r.headers.get("location", "")
+        check("callback redirect to client", loc.startswith("http://localhost:33418/callback"), loc)
+        check("redirect carries code+state", "code=" in loc and "state=" in loc, loc)
+        check("code bound to state in store", (await store.lookup_state_by_code(portal_code)) == state)
+
+        # 3. /token with bad PKCE -> invalid_grant
+        r = await c.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+                "code": portal_code,
+                "code_verifier": "WRONG_VERIFIER",
+            },
+        )
+        check("bad PKCE -> 400 invalid_grant", r.status_code == 400 and r.json().get("error") == "invalid_grant")
+
+        # 4. /token with correct PKCE -> 200 with access_token
+        r = await c.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+                "code": portal_code,
+                "code_verifier": CODE_VERIFIER,
+            },
+        )
+        check("good PKCE -> 200", r.status_code == 200, r.text)
+        tok = r.json()
+        check("token body has access_token", tok.get("access_token") == ISSUED_TOKEN)
+        check("token body has refresh_token", tok.get("refresh_token") == ISSUED_REFRESH)
+        check("Portal.exchange_code called once", stub.exchange_calls == 1)
+        # code+state should be evicted
+        check("state evicted after success", (await store.get_state(state)) is None)
+        check("code evicted after success", (await store.lookup_state_by_code(portal_code)) is None)
+
+        # 5. authed MCP call with the new bearer
+        r = await c.post(
+            "/juspay-dashboard-stream",
+            headers={"Authorization": f"Bearer {ISSUED_TOKEN}"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        check("authed call -> 200", r.status_code == 200)
+        check("merchant_id from Portal", r.json().get("merchant_id") == "STUB_MERCHANT")
+
+        # 6. validate cache: second call should NOT bump validate counter
+        prev = stub.validate_calls
+        await c.post(
+            "/juspay-dashboard-stream",
+            headers={"Authorization": f"Bearer {ISSUED_TOKEN}"},
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        )
+        check("validate cache prevents repeat Portal hit", stub.validate_calls == prev)
+
+        # 7. refresh_token grant
+        r = await c.post(
+            "/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+                "refresh_token": ISSUED_REFRESH,
+            },
+        )
+        check("refresh -> 200", r.status_code == 200)
+        check("refresh issued new access_token", r.json().get("access_token") == "portal-access-token-NEW")
+        check("Portal.refresh called once", stub.refresh_calls == 1)
+
+        # 8. invalid bearer -> 401 with invalid_token
+        r = await c.post(
+            "/juspay-dashboard-stream",
+            headers={"Authorization": "Bearer not-a-real-token"},
+            json={"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
+        )
+        check("invalid token -> 401", r.status_code == 401)
+        wwa = r.headers.get("www-authenticate", "")
+        check("invalid token WWW-Authenticate has error=invalid_token", 'error="invalid_token"' in wwa, wwa)
+
+        # 9. resource mismatch -> invalid_target
+        r = await c.get(
+            "/oauth/authorize",
+            params={
+                "client_id": "x",
+                "redirect_uri": "http://localhost/cb",
+                "state": "s2",
+                "code_challenge": CODE_CHALLENGE,
+                "code_challenge_method": "S256",
+                "resource": "https://evil.example.com/mcp",
+            },
+            follow_redirects=False,
+        )
+        check("foreign resource -> 400 invalid_target", r.status_code == 400 and r.json().get("error") == "invalid_target")
+
+        # 10. revoke — calls Portal, evicts validation cache, subsequent
+        # /juspay-dashboard-stream with the revoked bearer must 401.
+        # First prime the cache with one authed call.
+        r = await c.post(
+            "/juspay-dashboard-stream",
+            headers={"Authorization": f"Bearer {ISSUED_TOKEN}"},
+            json={"jsonrpc": "2.0", "id": 10, "method": "tools/list"},
+        )
+        check("pre-revoke authed call -> 200", r.status_code == 200)
+        check("token is in validation cache", ISSUED_TOKEN in validation_cache)
+
+        prev_revoke_calls = len(stub.revoke_calls)
+        r = await c.post(
+            "/oauth/revoke",
+            data={
+                "token": ISSUED_TOKEN,
+                "client_id": "test-client",
+                "client_secret": "test-secret",
+            },
+        )
+        check("revoke -> 200", r.status_code == 200, r.text)
+        check("revoke body says revoked=true", r.json().get("revoked") is True, r.text)
+        check(
+            "Portal.revoke_token called with correct args",
+            stub.revoke_calls[-1] == ("test-client", ISSUED_TOKEN),
+        )
+        check(
+            "Portal.revoke_token called exactly once for this revoke",
+            len(stub.revoke_calls) == prev_revoke_calls + 1,
+        )
+        check("validation cache evicted", ISSUED_TOKEN not in validation_cache)
+
+        # 11. Post-revoke: same bearer must now 401 because Portal validation
+        # is forced (cache miss) and the stub marks the token as revoked.
+        r = await c.post(
+            "/juspay-dashboard-stream",
+            headers={"Authorization": f"Bearer {ISSUED_TOKEN}"},
+            json={"jsonrpc": "2.0", "id": 11, "method": "tools/list"},
+        )
+        check("post-revoke call -> 401", r.status_code == 401)
+
+        # 12. /oauth/revoke without a token still 200 per RFC 7009 §2.2.
+        r = await c.post("/oauth/revoke", data={"client_id": "test-client"})
+        check("revoke without token still 200", r.status_code == 200)
+        check("revoke without token revoked=false", r.json().get("revoked") is False, r.text)
+
+    print()
+    if failures:
+        print(f"{FAIL} {failures} assertion(s) failed")
+        sys.exit(1)
+    print(f"{PASS} all flow checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Adds an OAuth 2.1 authorization subsystem to `juspay-mcp` so it can be added as a remote HTTP MCP server in **Claude Code** (and any other OAuth-aware MCP client) with a real browser-driven SSO flow against **Juspay Portal** — the same identity provider `juspay-genius/genius-mcp-app` already uses. Behavior is gated by `OAUTH_ENABLED` so existing header-based callers (`JUSPAY_API_KEY` / `JUSPAY_MERCHANT_ID` / `JUSPAY_WEB_LOGIN_TOKEN`) keep working unchanged.

Also adds four new dashboard tools (28 → 32 total), all verified live against Portal (merchant `paypal-juspay`, `merchantAccountId 3077`).

## Why

Today, anyone hitting `mcp.juspay.in` has to be issued a `JUSPAY_WEB_LOGIN_TOKEN` out-of-band and pass it via a custom header. There's no standardized way for individual developers to authenticate themselves against the MCP — they have to be proxied through `genius-mcp-app` or hand-injected. Following the **MCP 2025-06 authorization profile** (OAuth 2.1 + RFC 8414 + RFC 9728 + RFC 7591 + RFC 8707 + PKCE S256 + RFC 7009), Claude Code's built-in `/mcp` OAuth flow can drive a Juspay Portal login automatically and store the resulting bearer in the OS keychain.

## What's in here

### OAuth subsystem (`juspay_mcp/auth/`, ~700 LOC, gated by `OAUTH_ENABLED`)

| Concern | Endpoint / file |
|---|---|
| RFC 9728 protected-resource metadata | `GET /.well-known/oauth-protected-resource` (root + per-mount) |
| RFC 8414 authorization-server metadata | `GET /.well-known/oauth-authorization-server` (+ `openid-configuration` alias) |
| Empty JWKS | `GET /.well-known/jwks.json` |
| RFC 7591 dynamic client registration | `POST /oauth/register` |
| PKCE S256 authorization code flow | `GET /oauth/authorize` → Portal SSO 302; `GET /oauth/callback`; `POST /oauth/token` |
| RFC 7009 revocation | `POST /oauth/revoke` → Portal `DELETE /ec/v1/token/revoke/entity` + evicts the bearer from the validation cache |
| Bearer auth on every MCP request | `BearerAuthMiddleware` validates via Portal `/ec/v2/authorize` with a TTL'd LRU cache; emits proper 401 + `WWW-Authenticate` |
| TTL state store | in-memory; pluggable interface for Redis later |

### Four new dashboard tools

| Tool | What it does |
|---|---|
| `juspay_get_merchant_details` | Returns merchant/user session info from Portal (merchantId, userId, email, tenantAccountId, ACLs, context). "Who am I" call. |
| `juspay_create_api_key` | Settings → Security: provisions a new merchant API key. Plaintext `apiKey` returned once. |
| `juspay_update_general_settings` | Update payment redirect URL (empty string clears it). |
| `juspay_update_webhook_settings` | Set webhook URL + replace event subscriptions. Takes a plain list of event names; handler builds the `{event: true}` dict + boilerplate `webhookConfigs` JSON the API expects. |

### Plumbing changes

- `juspay_dashboard_mcp/api/utils.py`: new `put()` helper alongside `post()` (tolerant of non-JSON `"Success"` responses). `get_juspay_host_from_api` and `get_admin_host` now fall back to `juspay_creds["auth_type"]` when `meta_info` doesn't carry it — lets OAuth-sourced requests hit `/ec/v2/authorize` instead of the legacy `/api/ec/v1/validate/token` (which 400s on OAuth tokens).
- `BearerAuthMiddleware` tags request-scoped creds with `auth_type="oauth"` so existing handlers light up the correct validation path without any changes to their call sites.
- `juspay_mcp/main.py`: `dotenv.load_dotenv()` moved to module top so `.env` populates `JUSPAY_MCP_TYPE` / `OAUTH_ENABLED` before the import-time DASHBOARD-vs-CORE branching.

## Backward compatibility

- **`OAUTH_ENABLED=false` (default)**: `JuspayHeaderAuthMiddleware` remains in place. `genius-mcp-app`'s `JUSPAY_WEB_LOGIN_TOKEN` header path is untouched. No existing tool is modified.
- **All 28 existing tools**: untouched. New tools are purely additive.
- **No hardcoded base URLs in new code**: `MCP_SERVER_URL` and `PORTAL_BASE_URL` are env-driven (with safe defaults); dashboard handlers use `host` from the existing `get_juspay_host_from_api()` / `get_admin_host()` which in turn read `JUSPAY_PROD_BASE_URL` / `JUSPAY_SANDBOX_BASE_URL`.

### One subtle behavior change to flag

`dotenv.load_dotenv()` previously ran **after** `JUSPAY_MCP_TYPE = os.getenv(...)`, meaning `.env` values for `JUSPAY_MCP_TYPE` / `DOCS_MCP_V2_ENABLED` were silently ignored at import time. They're now honored. This is technically a bug fix but worth knowing if any deployment was implicitly relying on the old behavior.

## How to enable

1. Register an OAuth client on Juspay Portal with redirect URI `${MCP_SERVER_URL}/oauth/callback`.
2. Set env vars:
   ```
   OAUTH_ENABLED=true
   MCP_SERVER_URL=https://mcp.juspay.in
   PORTAL_BASE_URL=https://portal.juspay.in
   OAUTH_CLIENT_ID=<from secret manager>
   OAUTH_CLIENT_SECRET=<from secret manager>
   ```
3. Restart. Add to Claude Code:
   ```
   claude mcp add --transport http juspay https://mcp.juspay.in/juspay-dashboard-stream
   /mcp        # Authenticate → browser opens to Portal SSO → done
   ```

## Test plan

- [x] `tools_test/smoke_oauth.py` — 33 in-process ASGI assertions covering discovery, DCR, 401 challenge shape, dev-token auth, authorize 302.
- [x] `tools_test/smoke_oauth_flow.py` — 30 assertions for the full `/authorize` → `/callback` → `/token` (PKCE) → authed call → validate-cache → refresh → invalid-token → RFC 8707 audience rejection → revoke + cache eviction → post-revoke 401 path (stubbed `PortalClient`).
- [x] `tools_test/smoke_legacy_off.py` — confirms `OAUTH_ENABLED` flag flips correctly in both directions.
- [x] Live against Juspay Portal: all 4 new tools called from Claude Code, real merchant data returned, full OAuth handshake including DCR, PKCE, revocation, and re-auth.
- [ ] Reviewer: confirm port `8080` choice doesn't conflict with anything in your prod deployment topology (we ran locally on `9080` because port `8080` was hijacked by Docker Desktop NAT on the dev machine — the prod canonical URL won't have that issue).

## Files

```
 juspay_mcp/main.py                             | +87 -16  OAuth wiring (feature-flagged)
 juspay_mcp/auth/__init__.py                    | new
 juspay_mcp/auth/config.py                      | new      env-driven OAuthConfig
 juspay_mcp/auth/context.py                     | new      PortalUserInfo ContextVar
 juspay_mcp/auth/metadata.py                    | new      RFC 9728 / 8414 builders
 juspay_mcp/auth/middleware.py                  | new      BearerAuthMiddleware
 juspay_mcp/auth/pkce.py                        | new      S256 helpers
 juspay_mcp/auth/portal_client.py               | new      async Portal API client
 juspay_mcp/auth/routes.py                      | new      /.well-known/* + /oauth/*
 juspay_mcp/auth/state_store.py                 | new      TTL'd in-memory state
 juspay_dashboard_mcp/api/account.py            | new      get_merchant_details handler
 juspay_dashboard_mcp/api/api_keys.py           | new      create_api_key handler
 juspay_dashboard_mcp/api/settings.py           | +63 -1   2 update handlers + json import
 juspay_dashboard_mcp/api/utils.py              | +47 -3   put() + auth_type fallbacks
 juspay_dashboard_mcp/api_schema/account.py     | new
 juspay_dashboard_mcp/api_schema/api_keys.py    | new
 juspay_dashboard_mcp/api_schema/settings.py    | +66 -1
 juspay_dashboard_mcp/tools.py                  | +56 -0   registers 4 new tools
 tools_test/smoke_oauth.py                      | new
 tools_test/smoke_oauth_flow.py                 | new
 tools_test/smoke_legacy_off.py                 | new
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)