### PR TITLE
fix(auth): add OIDC-required fields to authorization-server metadata

### DIFF
--- a/juspay_mcp/auth/metadata.py
+++ b/juspay_mcp/auth/metadata.py
@@ -54,5 +54,13 @@ def authorization_server_metadata(cfg: OAuthConfig) -> dict:
             "client_secret_basic",
             "none",
         ],
+        # OpenID Connect Discovery REQUIRED fields. We are an OAuth 2.0
+        # authorization server, not a full OIDC provider, but this same
+        # document is also served at /.well-known/openid-configuration —
+        # and MCP clients validate that endpoint strictly against the
+        # OpenID Provider Metadata schema, which mandates these two arrays.
+        # Omitting them makes strict clients reject the connection.
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
         "service_documentation": "https://docs.juspay.in",
     }


### PR DESCRIPTION
## Problem

The deployed OAuth-protected service (`https://mcp.juspay.in/dashboard`, `OAUTH_ENABLED=true`) rejects MCP client reconnection with a Zod validation error:

```
Failed to reconnect to juspay-mcp: [
  { "path": ["subject_types_supported"],
    "code": "invalid_type", "expected": "array", "message": "expected array, received undefined" },
  { "path": ["id_token_signing_alg_values_supported"],
    "code": "invalid_type", "expected": "array", "message": "expected array, received undefined" }
]
```

## Root cause

`authorization_server_metadata()` (`juspay_mcp/auth/metadata.py`) emits an **OAuth 2.0 Authorization Server Metadata** document (RFC 8414). We serve that same document at two endpoints:

- `/.well-known/oauth-authorization-server` — validated as OAuth 2.0 AS metadata
- `/.well-known/openid-configuration` — validated as **OpenID Provider Metadata**

`subject_types_supported` and `id_token_signing_alg_values_supported` are **REQUIRED** by OpenID Connect Discovery but are *not* part of OAuth 2.0 AS metadata, so they were absent. When an MCP client hits the `openid-configuration` alias and validates the response strictly against the OIDC schema, those two missing required arrays fail validation and the client refuses to connect.

Discovery itself worked — the document was fetched fine. This is purely a missing-fields problem.

## Fix

Add both fields to the metadata document with standard values:

```python
"subject_types_supported": ["public"],
"id_token_signing_alg_values_supported": ["RS256"],
```

- Harmless extra fields for pure OAuth-2.0 clients (ignored).
- Makes the same document valid under **both** the OAuth 2.0 AS Metadata schema and the OpenID Connect Discovery schema.
- We do not issue ID tokens; `RS256` is the conventional required-field filler (OIDC mandates RS256 be advertised).

## Verification

- Confirmed the emitted document now contains all 7 OpenID-Provider-Metadata required fields (`issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`, `response_types_supported`, `subject_types_supported`, `id_token_signing_alg_values_supported`).
- `tools_test/smoke_oauth.py` and `smoke_oauth_flow.py` still pass.

## Deploy note

This needs to ship to the `mcp.juspay.in` deployment to clear the reconnect failure — include it in the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)