### PR TITLE
feat(docs-mcp)

### DIFF
--- a/juspay_docs_mcp/server.py
+++ b/juspay_docs_mcp/server.py
@@ -14,16 +14,11 @@ Tools:
 Discovery runs once at module import; results are persisted to snapshot.json.
 """
 
-import json
 import logging
-import os
-import re
-from contextvars import ContextVar
 from typing import Annotated, Optional
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 import httpx
-from markdownify import markdownify
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
@@ -33,43 +28,25 @@ from juspay_docs_mcp.instructions import INSTRUCTIONS
 logger = logging.getLogger(__name__)
 
 
-# ----------------------------------------------------------------------------
-# Per-request credentials (ContextVar populated by middleware in juspay_mcp.main)
-# ----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Static domain allowlist
+# ---------------------------------------------------------------------------
 
-juspay_request_credentials: ContextVar[Optional[dict]] = ContextVar(
-    "juspay_request_credentials", default=None
-)
-
-
-def set_juspay_request_credentials(credentials):
-    """Set Juspay credentials for the current request context."""
-    juspay_request_credentials.set(credentials)
+_ALLOWED_SUFFIXES = (".juspay.io", ".juspay.in")
+_ALLOWED_EXACT = frozenset({"juspay.io", "juspay.in", "dth95m2xtyv8v.cloudfront.net"})
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_ALLOWED_DOMAINS_DISPLAY = "*.juspay.io, *.juspay.in, dth95m2xtyv8v.cloudfront.net"
 
 
-def get_juspay_request_credentials():
-    """Get Juspay credentials from current request context."""
-    return juspay_request_credentials.get()
-
-
-# ----------------------------------------------------------------------------
-# Transcripts (curated commentary appended to specific URLs in doc_fetch_tool)
-# ----------------------------------------------------------------------------
-
-def _load_transcripts() -> dict:
-    path = os.path.join(os.path.dirname(__file__), "transcripts.json")
-    try:
-        with open(path, "r") as f:
-            return {str(k): str(v) for k, v in json.load(f).items()}
-    except FileNotFoundError:
-        logger.info("No transcripts.json at %s; running without transcripts", path)
-        return {}
-    except json.JSONDecodeError as e:
-        logger.warning("Failed to parse transcripts.json: %s", e)
-        return {}
-
-
-_TRANSCRIPTS_MAP = _load_transcripts()
+def _url_allowed(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        return False
+    # hostname is lowercased and strips the port.
+    host = parsed.hostname or ""
+    if host in _ALLOWED_EXACT:
+        return True
+    return any(host.endswith(s) for s in _ALLOWED_SUFFIXES)
 
 
 # ----------------------------------------------------------------------------
@@ -112,10 +89,10 @@ _CATEGORIES: list[str] = sorted({
 _CAT_HINT: str = ", ".join(_CATEGORIES) if _CATEGORIES else "(none discovered)"
 
 logger.info(
-    "Docs MCP initialized: %d products across %d categories, %d allowed domains",
+    "Docs MCP initialized: %d products across %d categories (allowed: %s)",
     len(_ENRICHED_SOURCES),
     len(_CATEGORIES),
-    len(_DOMAINS),
+    _ALLOWED_DOMAINS_DISPLAY,
 )
 
 
@@ -134,39 +111,15 @@ _HTTPX = httpx.AsyncClient(
 # Helpers
 # ----------------------------------------------------------------------------
 
-_META_REFRESH_RE = re.compile(
-    r'<meta http-equiv="refresh" content="[^;]+;\s*url=([^"]+)"',
-    re.IGNORECASE,
-)
 
 
-def _url_allowed(url: str) -> bool:
-    return any(url.startswith(d) for d in _DOMAINS)
 
-
-async def _fetch_with_processing(url: str) -> str:
-    """Fetch URL, follow meta-refresh once, inject transcript, markdownify."""
+async def _fetch(url: str) -> str:
+    """Fetch URL and return the raw response text."""
     try:
         response = await _HTTPX.get(url)
         response.raise_for_status()
-        content = response.text
-
-        m = _META_REFRESH_RE.search(content)
-        if m:
-            new_url = urljoin(str(response.url), m.group(1))
-            if not _url_allowed(new_url):
-                return (
-                    f"Error: redirect URL not allowed. "
-                    f"Allowed domains: {', '.join(sorted(_DOMAINS))}"
-                )
-            response = await _HTTPX.get(new_url)
-            response.raise_for_status()
-            content = response.text
-
-        if url in _TRANSCRIPTS_MAP:
-            content = content + "\n\n---\n\n" + _TRANSCRIPTS_MAP[url]
-
-        return markdownify(content)
+        return response.text
     except (httpx.HTTPStatusError, httpx.RequestError) as e:
         return f"Encountered an HTTP error: {e}"
 
@@ -255,11 +208,10 @@ async def explore_product(
 ) -> str:
     """Fetch the llms.txt index for a specific Juspay product.
 
-    Looks up the product slug in the discovered catalog and returns its
-    documentation index as markdown. The index contains .md content links
-    that you can read via doc_fetch_tool(url).
+    Looks up the product slug in the catalog and returns the raw llms.txt
+    content. The index contains .md content links readable via doc_fetch_tool(url).
 
-    Returns an error if the slug isn't in the catalog - call list_products()
+    Returns an error if the slug isn't in the catalog — call list_products()
     to see valid slugs.
     """
     entry = _SLUG_INDEX.get(product)
@@ -274,7 +226,7 @@ async def explore_product(
             f"Call list_products() to see all slugs. "
             f"Examples: {sample}{more}."
         )
-    return await _fetch_with_processing(entry["llms_txt"])
+    return await _fetch(entry["llms_txt"])
 
 
 @mcp.tool()
@@ -283,25 +235,24 @@ async def doc_fetch_tool(
         str,
         Field(
             description=(
-                "URL to fetch. Must be on an allowed domain (auto-derived "
-                "from the discovered product catalog, typically juspay.io)."
+                f"URL to fetch. Must be on an allowed domain: {_ALLOWED_DOMAINS_DISPLAY}."
             ),
         ),
     ],
 ) -> str:
-    """Fetch any allowed Juspay docs URL as markdown.
+    """Fetch any allowed Juspay docs URL and return its raw text content.
 
     Use this after explore_product() to read specific pages by URL.
-    Follows meta-refresh redirects once. Returns markdown-converted
-    content. Returns an error if the URL is on a disallowed domain.
+    Returns markdown mirror of the URL.
+    Returns an error if the URL is on a disallowed domain.
     """
     url = url.strip()
     if not _url_allowed(url):
         return (
-            f"Error: URL not allowed. Must start with one of: "
-            f"{', '.join(sorted(_DOMAINS))}"
+            f"Error: URL not on an allowed domain. "
+            f"Allowed: {_ALLOWED_DOMAINS_DISPLAY}"
         )
-    return await _fetch_with_processing(url)
+    return await _fetch(url)
 
 
 # Export the underlying low-level Server for main.py / stdio.py

--- a/juspay_docs_mcp/snapshot.json
+++ b/juspay_docs_mcp/snapshot.json
@@ -1,5 +1,5 @@
 {
-  "fetched_at": "2026-05-15T10:02:42.687046Z",
+  "fetched_at": "2026-05-19T13:47:55.391152Z",
   "sources": [
     {
       "name": "Name: Juspay Billing\n\nEnd to end Mandate lifecycle. By using Billing, you treat Mandates as a configuration, not a codebase",

--- a/juspay_mcp/auth/middleware.py
+++ b/juspay_mcp/auth/middleware.py
@@ -56,6 +56,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         cfg: OAuthConfig,
         portal: PortalClient,
         validation_cache: dict[str, tuple[PortalUserInfo, float]] | None = None,
+        skip_path_prefixes: tuple[str, ...] = (),
     ) -> None:
         super().__init__(app)
         self._cfg = cfg
@@ -66,6 +67,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         self._cache: dict[str, tuple[PortalUserInfo, float]] = (
             validation_cache if validation_cache is not None else {}
         )
+        self._skip_path_prefixes = skip_path_prefixes
 
     async def _validate_with_cache(self, token: str) -> PortalUserInfo | None:
         # Dev bypass: useful for curl-driven smoke tests so we don't need a
@@ -131,7 +133,12 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        if _is_public_path(request.url.path):
+        path = request.url.path
+        if _is_public_path(path):
+            return await call_next(request)
+        if self._skip_path_prefixes and any(
+            path == p or path.startswith(p + "/") for p in self._skip_path_prefixes
+        ):
             return await call_next(request)
 
         auth_header = request.headers.get("authorization") or request.headers.get("Authorization")

--- a/juspay_mcp/auth/routes.py
+++ b/juspay_mcp/auth/routes.py
@@ -348,16 +348,18 @@ def build_routes(
         return JSONResponse({"revoked": revoked})
 
     # ---------- assemble ------------------------------------------------------
+    _WELL_KNOWN_METHODS = ["GET", "OPTIONS"]
+
     routes: list[Route] = [
-        Route("/.well-known/oauth-protected-resource", endpoint=prm_root, methods=["GET"]),
+        Route("/.well-known/oauth-protected-resource", endpoint=prm_root, methods=_WELL_KNOWN_METHODS),
         Route(
             "/{mount:str}/.well-known/oauth-protected-resource",
             endpoint=prm_for_mount,
-            methods=["GET"],
+            methods=_WELL_KNOWN_METHODS,
         ),
-        Route("/.well-known/oauth-authorization-server", endpoint=asm, methods=["GET"]),
-        Route("/.well-known/openid-configuration", endpoint=asm, methods=["GET"]),
-        Route("/.well-known/jwks.json", endpoint=jwks, methods=["GET"]),
+        Route("/.well-known/oauth-authorization-server", endpoint=asm, methods=_WELL_KNOWN_METHODS),
+        Route("/.well-known/openid-configuration", endpoint=asm, methods=_WELL_KNOWN_METHODS),
+        Route("/.well-known/jwks.json", endpoint=jwks, methods=_WELL_KNOWN_METHODS),
         Route("/oauth/register", endpoint=register, methods=["POST"]),
         Route("/oauth/authorize", endpoint=authorize, methods=["GET"]),
         Route("/oauth/callback", endpoint=callback, methods=["GET"]),

--- a/juspay_mcp/main.py
+++ b/juspay_mcp/main.py
@@ -104,18 +104,20 @@ def main(host: str, port: int, mode: str):
         return
     
     # Run in HTTP/SSE mode (default)
-    message_endpoint_path = "/messages/"
     if JUSPAY_MCP_TYPE == "DASHBOARD":
         # Dashboard MCP
         sse_dashboard_endpoint_path = "/juspay-dashboard"
         streamable_dashboard_endpoint_path = "/juspay-dashboard-stream"
+        dashboard_message_path = "/messages/"
 
-        # Docs MCP
+        # Docs MCP — own message path so it can be excluded from auth
         sse_docs_endpoint_path = "/juspay-docs"
         streamable_docs_endpoint_path = "/juspay-docs-stream"
+        docs_message_path = "/docs-messages/"
     else:
         sse_endpoint_path = "/juspay"
         streamable_endpoint_path = "/juspay-stream"
+        message_endpoint_path = "/messages/"
     
     oauth_cfg = auth_config.load()
     portal_client = None
@@ -133,16 +135,22 @@ def main(host: str, port: int, mode: str):
         logger.info("Running with header-based authentication")
         logger.info("Expected headers: JUSPAY_API_KEY, JUSPAY_MERCHANT_ID, JUSPAY_WEB_LOGIN_TOKEN")
 
-    sse_transport_handler = SseServerTransport(message_endpoint_path)
+    if JUSPAY_MCP_TYPE == "DASHBOARD":
+        sse_transport_handler = SseServerTransport(dashboard_message_path)
+        docs_sse_transport_handler = SseServerTransport(docs_message_path)
+    else:
+        sse_transport_handler = SseServerTransport(message_endpoint_path)
+
+    class _AlreadySentResponse(Response):
+        """No-op response — SSE/StreamableHTTP transport already wrote to send."""
+        async def __call__(self, scope, receive, send):
+            pass
 
     async def health_check(request: Request):
         return JSONResponse({"status": "ok"})
 
-    def make_sse_handler(active_app_key: str):
-        """
-        Returns an async endpoint function bound to a specific MCP app
-        (dashboard / docs / default).
-        """
+    def make_sse_handler(active_app_key: str, transport: SseServerTransport):
+        """Returns an async SSE endpoint bound to a specific MCP app and transport."""
         active_app = MCP_APPS[active_app_key]
 
         async def handler(request: Request):
@@ -150,22 +158,17 @@ def main(host: str, port: int, mode: str):
                 f"New SSE connection from: {request.client} - {request.method} {request.url.path}"
             )
 
-            # Choose correct set_juspay_request_credentials based on which app is active
-            if JUSPAY_MCP_TYPE == "DASHBOARD":
-                if active_app_key == "dashboard":
-                    from juspay_dashboard_mcp.tools import set_juspay_request_credentials
-                elif active_app_key == "docs":
-                    from juspay_docs_mcp.server import set_juspay_request_credentials
-                else:
-                    # Fallback (should not happen in DASHBOARD mode)
-                    from juspay_mcp.tools import set_juspay_request_credentials
-            else:
+            if active_app_key == "dashboard":
+                from juspay_dashboard_mcp.tools import set_juspay_request_credentials
+                juspay_creds = getattr(request.state, "juspay_credentials", None)
+                set_juspay_request_credentials(juspay_creds)
+            elif active_app_key == "default":
                 from juspay_mcp.tools import set_juspay_request_credentials
+                juspay_creds = getattr(request.state, "juspay_credentials", None)
+                set_juspay_request_credentials(juspay_creds)
+            # docs: no credentials needed
 
-            juspay_creds = getattr(request.state, "juspay_credentials", None)
-            set_juspay_request_credentials(juspay_creds)
-
-            async with sse_transport_handler.connect_sse(
+            async with transport.connect_sse(
                 request.scope, request.receive, request._send
             ) as streams:
                 logging.info(f"MCP Session starting for {request.client}")
@@ -181,6 +184,8 @@ def main(host: str, port: int, mode: str):
                     )
                 finally:
                     logging.info(f"MCP Session ended for {request.client}")
+
+            return _AlreadySentResponse()
 
         return handler
 
@@ -198,30 +203,21 @@ def main(host: str, port: int, mode: str):
             stateless=True,
         )
 
-        class _AlreadySentResponse(Response):
-            """No-op response — session_manager already wrote to send."""
-            async def __call__(self, scope, receive, send):
-                pass
-
         async def handle_streamable_http(request: Request):
             """Route-compatible endpoint for StreamableHTTP that handles credential injection."""
             logging.info(
                 f"New StreamableHTTP request from: {request.client} - {request.method} {request.url.path}"
             )
 
-            # Choose correct set_juspay_request_credentials based on which app is active
-            if JUSPAY_MCP_TYPE == "DASHBOARD":
-                if active_app_key == "dashboard":
-                    from juspay_dashboard_mcp.tools import set_juspay_request_credentials
-                elif active_app_key == "docs":
-                    from juspay_docs_mcp.server import set_juspay_request_credentials
-                else:
-                    from juspay_mcp.tools import set_juspay_request_credentials
-            else:
+            if active_app_key == "dashboard":
+                from juspay_dashboard_mcp.tools import set_juspay_request_credentials
+                juspay_creds = getattr(request.state, "juspay_credentials", None)
+                set_juspay_request_credentials(juspay_creds)
+            elif active_app_key == "default":
                 from juspay_mcp.tools import set_juspay_request_credentials
-
-            juspay_creds = getattr(request.state, "juspay_credentials", None)
-            set_juspay_request_credentials(juspay_creds)
+                juspay_creds = getattr(request.state, "juspay_credentials", None)
+                set_juspay_request_credentials(juspay_creds)
+            # docs: no credentials needed
 
             # session_manager writes the full HTTP response directly to send
             await session_manager.handle_request(request.scope, request.receive, request._send)
@@ -229,11 +225,19 @@ def main(host: str, port: int, mode: str):
 
         return handle_streamable_http, session_manager
 
-    routes = [
-        Route("/health", endpoint=health_check, methods=["GET"]),
-        Route("/health/ready", endpoint=health_check, methods=["GET"]),
-        Mount(message_endpoint_path, app=sse_transport_handler.handle_post_message),
-    ]
+    if JUSPAY_MCP_TYPE == "DASHBOARD":
+        routes = [
+            Route("/health", endpoint=health_check, methods=["GET"]),
+            Route("/health/ready", endpoint=health_check, methods=["GET"]),
+            Mount(dashboard_message_path, app=sse_transport_handler.handle_post_message),
+            Mount(docs_message_path, app=docs_sse_transport_handler.handle_post_message),
+        ]
+    else:
+        routes = [
+            Route("/health", endpoint=health_check, methods=["GET"]),
+            Route("/health/ready", endpoint=health_check, methods=["GET"]),
+            Mount(message_endpoint_path, app=sse_transport_handler.handle_post_message),
+        ]
 
     # Prepend OAuth discovery + /oauth/* routes before the MCP transport
     # routes so they win the longest-prefix match.
@@ -242,11 +246,11 @@ def main(host: str, port: int, mode: str):
 
     if JUSPAY_MCP_TYPE == "DASHBOARD":
         # Dashboard MCP
-        dashboard_sse_handler = make_sse_handler("dashboard")
+        dashboard_sse_handler = make_sse_handler("dashboard", sse_transport_handler)
         dashboard_http_handler, dashboard_session_mgr = make_streamable_http_handler("dashboard")
 
         # Docs MCP
-        docs_sse_handler = make_sse_handler("docs")
+        docs_sse_handler = make_sse_handler("docs", docs_sse_transport_handler)
         docs_http_handler, docs_session_mgr = make_streamable_http_handler("docs")
 
         routes.extend(
@@ -281,7 +285,7 @@ def main(host: str, port: int, mode: str):
             logger.info("StreamableHTTP session managers stopped")
 
     else:
-        default_sse_handler = make_sse_handler("default")
+        default_sse_handler = make_sse_handler("default", sse_transport_handler)
         default_http_handler, default_session_mgr = make_streamable_http_handler("default")
 
         routes.extend(
@@ -313,6 +317,15 @@ def main(host: str, port: int, mode: str):
             logger.info("StreamableHTTP session manager stopped")
 
     # Authentication middleware — OAuth bearer when enabled, else legacy header path.
+    # In DASHBOARD mode the docs endpoints are public (no auth required).
+    docs_skip_prefixes: tuple[str, ...] = ()
+    if JUSPAY_MCP_TYPE == "DASHBOARD":
+        docs_skip_prefixes = (
+            sse_docs_endpoint_path,
+            streamable_docs_endpoint_path,
+            docs_message_path,
+        )
+
     if oauth_cfg.enabled and portal_client is not None:
         middleware = [
             Middleware(
@@ -320,6 +333,7 @@ def main(host: str, port: int, mode: str):
                 cfg=oauth_cfg,
                 portal=portal_client,
                 validation_cache=oauth_validation_cache,
+                skip_path_prefixes=docs_skip_prefixes,
             ),
         ]
     else:


### PR DESCRIPTION
   ## juspay_docs_mcp/server.py
   - Remove per-request ContextVar credential plumbing (docs MCP needs no auth)
   - Remove transcript injection and markdownify post-processing from fetch
   - Replace dynamic domain derivation with a static allowlist: *.juspay.io, *.juspay.in, dth95m2xtyv8v.cloudfront.net
   - Rewrite _url_allowed() to match netloc exactly or by suffix rather than string-prefix on the full URL (prevents false-positive on typosquats like evil-juspay.io)

   ## juspay_mcp/auth/middleware.py
   - Add skip_path_prefixes parameter to BearerAuthMiddleware; paths that match (exact or with a '/' separator) bypass the bearer token check entirely
   - Tighten the existing startswith check to path == p or path.startswith(p+'/') so a path like /juspay-docs-evil cannot sneak past a /juspay-docs skip rule

   ## juspay_mcp/auth/routes.py
   - Add OPTIONS to all well-known route method lists so MCP client CORS preflights (OPTIONS /.well-known/...) return 200 instead of 405

   ## juspay_mcp/main.py
   - In DASHBOARD mode give docs its own SseServerTransport on /docs-messages/ (separate from dashboard's /messages/) so docs SSE post-message requests are not blocked by OAuth middleware
   - Add /docs-messages/ to docs_skip_prefixes alongside /juspay-docs and /juspay-docs-stream so the full docs SSE flow (connect + post) is auth-free
   - make_sse_handler now takes the transport as an explicit parameter instead of closing over a single shared sse_transport_handler
   - SSE handler now returns _AlreadySentResponse() instead of None — fixes TypeError: 'NoneType' object is not callable in Starlette's route wrapper that was crashing the ASGI app after every SSE session ended
   - Move _AlreadySentResponse to outer scope so it is shared between SSE and StreamableHTTP handlers (removes the duplicate inner class)
   - Credential injection for docs app_key is skipped (docs has no auth context)