### PR TITLE
ix(auth): add path-based protected resource metadata URL per MCP spec.

### DIFF
--- a/juspay_mcp/auth/routes.py
+++ b/juspay_mcp/auth/routes.py
@@ -9,7 +9,8 @@ Endpoint inventory (all mounted on the same Starlette app as the MCP transport
 endpoints):
 
   GET  /.well-known/oauth-protected-resource
-  GET  /<mount>/.well-known/oauth-protected-resource     (per-mount alias)
+  GET  /.well-known/oauth-protected-resource/<mount>     (per-mount, reverse)
+  GET  /<mount>/.well-known/oauth-protected-resource     (per-mount, forward)
   GET  /.well-known/oauth-authorization-server
   GET  /.well-known/openid-configuration                 (RFC 8414 alias)
   GET  /.well-known/jwks.json
@@ -352,6 +353,11 @@ def build_routes(
 
     routes: list[Route] = [
         Route("/.well-known/oauth-protected-resource", endpoint=prm_root, methods=_WELL_KNOWN_METHODS),
+        Route(
+            "/.well-known/oauth-protected-resource/{mount:str}",
+            endpoint=prm_for_mount,
+            methods=_WELL_KNOWN_METHODS,
+        ),
         Route(
             "/{mount:str}/.well-known/oauth-protected-resource",
             endpoint=prm_for_mount,


### PR DESCRIPTION
Adds Route("/.well-known/oauth-protected-resource/{mount:str}") alongside
the existing forward-mount convenience route, reusing prm_for_mount which
already returns the correct per-mount resource URL in the response body.

Ref: https://modelcontextprotocol.io/specification/draft/basic/authorization#protected-resource-metadata-discovery-requirements