### PR TITLE
fix(auth): correct per-mount PRM resource URL 

### DIFF
--- a/juspay_mcp/auth/middleware.py
+++ b/juspay_mcp/auth/middleware.py
@@ -104,7 +104,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         # Strip any trailing /messages or /stream suffix so we land on the
         # mount-level well-known doc.
-        base = path.rsplit("/", 1)[0] if path.count("/") > 1 else ""
+        base = path.rsplit("/", 1)[0] if path.count("/") > 1 else path
         prm_url = f"{self._cfg.mcp_server_url}{base}/.well-known/oauth-protected-resource"
         parts = [f'Bearer resource_metadata="{prm_url}"']
         if self._cfg.scopes_supported:

--- a/juspay_mcp/auth/routes.py
+++ b/juspay_mcp/auth/routes.py
@@ -132,9 +132,21 @@ def build_routes(
         return JSONResponse(protected_resource_metadata(cfg))
 
     async def prm_for_mount(request: Request) -> Response:
-        # `mount_path` arrives via path templating, e.g. /juspay-dashboard-stream
+        # Forward-form: /{mount}/.well-known/oauth-protected-resource
+        # mount is a single path segment, e.g. "juspay-dashboard-stream"
         mount = request.path_params["mount"]
         resource_url = f"{cfg.mcp_server_url}/{mount}"
+        return JSONResponse(protected_resource_metadata(cfg, resource_url=resource_url))
+
+    async def prm_reverse_form(request: Request) -> Response:
+        # Reverse-form (RFC 9728 §4): /.well-known/oauth-protected-resource/{full_path}
+        # full_path may span multiple segments, e.g. "dashboard/juspay-dashboard-stream"
+        # The resource URL is reconstructed from the host origin, not cfg.mcp_server_url,
+        # because the reverse-form encodes the full absolute path from the host root.
+        full_path = request.path_params["full_path"]
+        parsed = urlparse(cfg.mcp_server_url)
+        host_origin = f"{parsed.scheme}://{parsed.netloc}"
+        resource_url = f"{host_origin}/{full_path}"
         return JSONResponse(protected_resource_metadata(cfg, resource_url=resource_url))
 
     async def asm(_: Request) -> Response:
@@ -348,16 +360,23 @@ def build_routes(
         return JSONResponse({"revoked": revoked})
 
     # ---------- assemble ------------------------------------------------------
+    _WELL_KNOWN_METHODS = ["GET", "OPTIONS"]
+
     routes: list[Route] = [
-        Route("/.well-known/oauth-protected-resource", endpoint=prm_root, methods=["GET"]),
+        Route("/.well-known/oauth-protected-resource", endpoint=prm_root, methods=_WELL_KNOWN_METHODS),
+        Route(
+            "/.well-known/oauth-protected-resource/{full_path:path}",
+            endpoint=prm_reverse_form,
+            methods=_WELL_KNOWN_METHODS,
+        ),
         Route(
             "/{mount:str}/.well-known/oauth-protected-resource",
             endpoint=prm_for_mount,
-            methods=["GET"],
+            methods=_WELL_KNOWN_METHODS,
         ),
-        Route("/.well-known/oauth-authorization-server", endpoint=asm, methods=["GET"]),
-        Route("/.well-known/openid-configuration", endpoint=asm, methods=["GET"]),
-        Route("/.well-known/jwks.json", endpoint=jwks, methods=["GET"]),
+        Route("/.well-known/oauth-authorization-server", endpoint=asm, methods=_WELL_KNOWN_METHODS),
+        Route("/.well-known/openid-configuration", endpoint=asm, methods=_WELL_KNOWN_METHODS),
+        Route("/.well-known/jwks.json", endpoint=jwks, methods=_WELL_KNOWN_METHODS),
         Route("/oauth/register", endpoint=register, methods=["POST"]),
         Route("/oauth/authorize", endpoint=authorize, methods=["GET"]),
         Route("/oauth/callback", endpoint=callback, methods=["GET"]),


### PR DESCRIPTION

Two bugs caused OAuth failures across MCP clients:

1. Gemini / Windsurf — resource mismatch in WWW-Authenticate _challenge_header used `base = ""` for single-segment paths like `/juspay-dashboard-stream`, so the 401 pointed at the root PRM which returned `resource: "https://mcp.juspay.in/dashboard"` instead of `"…/juspay-dashboard-stream"`. Clients that strictly validate the resource identifier (per MCP spec § Canonical Server URI and RFC 9728) rejected the mismatch. Fix: use `else path` so the 401 header points at the per-mount PRM, which already returns the correct resource URL.

2. cursor-cli / copilot-ext — HTTP 404 with empty body RFC 9728 §4 / MCP spec § Protected Resource Metadata Discovery requires clients to probe the reverse-form well-known URL: /.well-known/oauth-protected-resource/dashboard/juspay-dashboard-stream The old route used `{mount:str}` which does not match across slashes, so multi-segment paths fell through to a 404 with a non-JSON body ("SyntaxError: Unexpected end of JSON input"). 
Fix: add prm_reverse_form handler with `{full_path:path}`. Resource URL is built from host origin + full_path, matching the spec example: "https://example.com/public/mcp" → "…/.well-known/…/public/mcp" Also adds OPTIONS to all well-known routes for CORS preflight.