### PR TITLE
feat: CLI analytics — emit install/session telemetry to genius

### DIFF
--- a/juspay_dashboard_mcp/tools.py
+++ b/juspay_dashboard_mcp/tools.py
@@ -8,13 +8,22 @@ import json
 import mcp.types as types
 import inspect
 import logging
+import os
+import time
 from mcp.server.lowlevel import Server
 from mcp.server.sse import SseServerTransport
 
+from juspay_mcp.analytics import record_tool_call
+from juspay_mcp.analytics.config import is_local_development
+from juspay_mcp.analytics.identity import (
+    extract_mid as extract_analytics_mid,
+    resolve_mid_from_dashboard_token,
+)
 from juspay_dashboard_mcp import response_schema
 from juspay_dashboard_mcp.api import *
 import juspay_dashboard_mcp.api_schema as api_schema
 import juspay_dashboard_mcp.utils as util
+from juspay_dashboard_mcp.config import JUSPAY_BASE_URL
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +39,68 @@ def set_juspay_request_credentials(credentials):
 def get_juspay_request_credentials():
     """Get Juspay credentials from current request context."""
     return juspay_request_credentials.get()
+
+
+def _dashboard_token_for_analytics(juspay_creds: dict | None, meta_info: dict | None) -> str | None:
+    if isinstance(juspay_creds, dict) and juspay_creds.get("dashboard_token"):
+        return str(juspay_creds["dashboard_token"])
+    if isinstance(meta_info, dict) and meta_info.get("x-web-logintoken"):
+        return str(meta_info["x-web-logintoken"])
+    if not is_local_development():
+        return None
+    return os.environ.get("JUSPAY_WEB_LOGIN_TOKEN")
+
+
+async def _mid_for_analytics(
+    *,
+    response: object | None,
+    juspay_creds: dict | None,
+    meta_info: dict | None,
+) -> str | None:
+    mid = extract_analytics_mid(response)
+    if mid:
+        return mid
+    mid = extract_analytics_mid(juspay_creds)
+    if mid:
+        return mid
+    if is_local_development():
+        mid = os.environ.get("JUSPAY_MERCHANT_ID")
+        if mid:
+            return mid.strip() or None
+    return await resolve_mid_from_dashboard_token(
+        token=_dashboard_token_for_analytics(juspay_creds, meta_info),
+        portal_base_url=JUSPAY_BASE_URL,
+    )
+
+
+async def _safe_record_tool_call(
+    *,
+    tool: str,
+    status: str,
+    started_at: float,
+    arguments: dict,
+    response: object | None = None,
+    juspay_creds: dict | None = None,
+    meta_info: dict | None = None,
+    error: str | None = None,
+) -> None:
+    try:
+        analytics_mid = await _mid_for_analytics(
+            response=response,
+            juspay_creds=juspay_creds,
+            meta_info=meta_info,
+        )
+        await record_tool_call(
+            tool=tool,
+            status=status,
+            started_at=started_at,
+            arguments=arguments,
+            error=error,
+            mid=analytics_mid,
+        )
+    except Exception:
+        logger.exception("Failed to emit dashboard analytics event for %s", tool)
+
 
 AVAILABLE_TOOLS = [
     util.make_api_config(
@@ -698,7 +769,9 @@ async def list_my_tools() -> list[types.Tool]:
 
 @app.call_tool()
 async def handle_tool_calls(name: str, arguments: dict) -> list[types.TextContent]:
-    logger.info(f"Tool called: {name} with arguments: {arguments}")
+    started_at = time.perf_counter()
+    analytics_arguments = dict(arguments or {})
+    logger.info("Tool called: %s", name)
     try:
         # Import here to avoid circular imports
         from juspay_dashboard_mcp.api.utils import set_juspay_credentials
@@ -754,8 +827,25 @@ async def handle_tool_calls(name: str, arguments: dict) -> list[types.TextConten
 
         else:
             raise ValueError(f"Unsupported number of parameters in tool handler: {param_count}")
+        await _safe_record_tool_call(
+            tool=name,
+            status="success",
+            started_at=started_at,
+            arguments=analytics_arguments,
+            response=response,
+            juspay_creds=juspay_creds,
+            meta_info=meta_info,
+        )
         return [types.TextContent(type="text", text=json.dumps(response))]
 
     except Exception as e:
         logger.error(f"Error in tool execution: {e}")
+        await _safe_record_tool_call(
+            tool=name,
+            status="error",
+            started_at=started_at,
+            arguments=analytics_arguments,
+            juspay_creds=get_juspay_request_credentials(),
+            error=str(e),
+        )
         return [types.TextContent(type="text", text=f"ERROR: Tool execution failed: {str(e)}")]

--- a/juspay_docs_mcp/server.py
+++ b/juspay_docs_mcp/server.py
@@ -15,13 +15,15 @@ Discovery runs once at module import; results are persisted to snapshot.json.
 """
 
 import logging
-from typing import Annotated, Optional
+import time
+from typing import Annotated, Any, Literal, Optional
 from urllib.parse import urlparse
 
 import httpx
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
+from juspay_mcp.analytics import record_stage_status, record_tool_call
 from juspay_docs_mcp.discovery import load_dynamic_doc_sources
 from juspay_docs_mcp.genius import ask_genius
 from juspay_docs_mcp.instructions import INSTRUCTIONS
@@ -132,6 +134,79 @@ async def _fetch(url: str) -> str:
 mcp = FastMCP(name="juspay-docs", instructions=INSTRUCTIONS)
 
 
+async def _safe_record_tool_call(
+    *,
+    tool: str,
+    status: str,
+    started_at: float,
+    arguments: dict[str, Any],
+    error: str | None = None,
+) -> None:
+    try:
+        await record_tool_call(
+            tool=tool,
+            status=status,
+            started_at=started_at,
+            arguments=arguments,
+            error=error,
+        )
+    except Exception:
+        logger.exception("Failed to emit docs analytics event for %s", tool)
+
+
+@mcp.tool()
+async def juspay_track_integration_stage(
+    phase: Annotated[
+        Literal["setup", "prd", "architecture", "backend", "frontend", "validation", "live"],
+        Field(
+            description=(
+                "Integration funnel phase being reported. Use this as the final "
+                "action when a phase is completed or otherwise resolved."
+            )
+        ),
+    ],
+    status: Annotated[
+        Literal["started", "completed", "failed", "skipped"],
+        Field(description="Status of the integration phase."),
+    ],
+    product: Annotated[
+        Optional[str],
+        Field(description="Selected Juspay product, if known."),
+    ] = None,
+    platform: Annotated[
+        Optional[str],
+        Field(description="Selected platform such as web, react-native, android, or ios."),
+    ] = None,
+    framework: Annotated[
+        Optional[str],
+        Field(description="Selected application framework, if known."),
+    ] = None,
+    metadata: Annotated[
+        Optional[dict[str, Any]],
+        Field(description="Small JSON object with non-sensitive stage metadata."),
+    ] = None,
+) -> str:
+    """Record a merchant integration funnel milestone for analytics.
+
+    This tool is intentionally unauthenticated so docs-only integration journeys
+    can still emit milestones. The server joins events to MID later when a
+    dashboard-authenticated request appears with the same install id.
+    """
+    try:
+        await record_stage_status(
+            phase=phase,
+            status=status,
+            product=product,
+            platform=platform,
+            framework=framework,
+            metadata=metadata,
+        )
+    except Exception:
+        logger.exception("Failed to record integration stage analytics")
+        return "Stage status accepted; analytics write failed."
+    return "Stage status recorded."
+
+
 @mcp.tool()
 async def juspay_genius_docs(
     query: Annotated[
@@ -153,47 +228,52 @@ async def juspay_genius_docs(
     read in full with doc_fetch_tool(url). Genius is the public docs assistant
     (distinct from the dashboard's rag_tool_juspay).
     """
+    started_at = time.perf_counter()
+    status = "success"
+    error = None
     try:
-        result = await ask_genius(query)
-    except (httpx.HTTPError, httpx.TimeoutException) as e:
-        logger.warning("Genius docs call failed: %s", e)
-        return (
-            "The Genius docs assistant is unavailable right now. "
-            "Use list_products / explore_product / doc_fetch_tool to navigate "
-            "the docs directly, or retry shortly."
+        try:
+            result = await ask_genius(query)
+        except httpx.TimeoutException as e:
+            status = "timeout"
+            error = str(e) or "Genius docs request timed out"
+            logger.warning("Genius docs call timed out: %s", e)
+            return (
+                "The Genius docs assistant timed out. "
+                "Use list_products / explore_product / doc_fetch_tool to navigate "
+                "the docs directly, or retry shortly."
+            )
+        except httpx.HTTPError as e:
+            status = "error"
+            error = str(e)
+            logger.warning("Genius docs call failed: %s", e)
+            return (
+                "The Genius docs assistant is unavailable right now. "
+                "Use list_products / explore_product / doc_fetch_tool to navigate "
+                "the docs directly, or retry shortly."
+            )
+
+        answer = result["answer"] or "(no answer returned)"
+        sources = result["sources"]
+        if sources:
+            listed = "\n".join(f"- {s['title']}: {s['url']}" for s in sources)
+            return f"{answer}\n\nSources:\n{listed}"
+        return answer
+    except Exception as e:
+        status = "error"
+        error = str(e)
+        raise
+    finally:
+        await _safe_record_tool_call(
+            tool="juspay_genius_docs",
+            status=status,
+            started_at=started_at,
+            arguments={"query": query},
+            error=error,
         )
 
-    answer = result["answer"] or "(no answer returned)"
-    sources = result["sources"]
-    if sources:
-        listed = "\n".join(f"- {s['title']}: {s['url']}" for s in sources)
-        return f"{answer}\n\nSources:\n{listed}"
-    return answer
 
-
-@mcp.tool()
-def list_products(
-    category: Annotated[
-        Optional[str],
-        Field(
-            description=(
-                "Optional category filter (case-insensitive). When omitted, "
-                f"all {len(_ENRICHED_SOURCES)} products are returned. "
-                f"Available categories: {_CAT_HINT}."
-            ),
-        ),
-    ] = None,
-) -> str:
-    """Browse the Juspay product catalog.
-
-    Use this first to discover which Juspay product is relevant to the
-    user's question. Returns title, slug, category, URL, and a short
-    description for each product. Optionally filter by category (e.g.
-    'CHECKOUT', 'BILLING', 'DASHBOARD').
-
-    After choosing a product, call explore_product(slug) to fetch its
-    llms.txt index.
-    """
+def _list_products(category: Optional[str] = None) -> str:
     if category:
         cat_lower = category.lower()
         matched = [
@@ -235,6 +315,48 @@ def list_products(
 
 
 @mcp.tool()
+async def list_products(
+    category: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional category filter (case-insensitive). When omitted, "
+                f"all {len(_ENRICHED_SOURCES)} products are returned. "
+                f"Available categories: {_CAT_HINT}."
+            ),
+        ),
+    ] = None,
+) -> str:
+    """Browse the Juspay product catalog.
+
+    Use this first to discover which Juspay product is relevant to the
+    user's question. Returns title, slug, category, URL, and a short
+    description for each product. Optionally filter by category (e.g.
+    'CHECKOUT', 'BILLING', 'DASHBOARD').
+
+    After choosing a product, call explore_product(slug) to fetch its
+    llms.txt index.
+    """
+    started_at = time.perf_counter()
+    status = "success"
+    error = None
+    try:
+        return _list_products(category)
+    except Exception as e:
+        status = "error"
+        error = str(e)
+        raise
+    finally:
+        await _safe_record_tool_call(
+            tool="list_products",
+            status=status,
+            started_at=started_at,
+            arguments={"category": category},
+            error=error,
+        )
+
+
+@mcp.tool()
 async def explore_product(
     product: Annotated[
         str,
@@ -254,19 +376,35 @@ async def explore_product(
     Returns an error if the slug isn't in the catalog — call list_products()
     to see valid slugs.
     """
-    entry = _SLUG_INDEX.get(product)
-    if entry is None:
-        sample = ", ".join(sorted(_SLUG_INDEX.keys())[:10])
-        more = (
-            f" (and {len(_SLUG_INDEX) - 10} more)"
-            if len(_SLUG_INDEX) > 10 else ""
+    started_at = time.perf_counter()
+    status = "success"
+    error = None
+    try:
+        entry = _SLUG_INDEX.get(product)
+        if entry is None:
+            sample = ", ".join(sorted(_SLUG_INDEX.keys())[:10])
+            more = (
+                f" (and {len(_SLUG_INDEX) - 10} more)"
+                if len(_SLUG_INDEX) > 10 else ""
+            )
+            return (
+                f"Product slug {product!r} not found in catalog. "
+                f"Call list_products() to see all slugs. "
+                f"Examples: {sample}{more}."
+            )
+        return await _fetch(entry["llms_txt"])
+    except Exception as e:
+        status = "error"
+        error = str(e)
+        raise
+    finally:
+        await _safe_record_tool_call(
+            tool="explore_product",
+            status=status,
+            started_at=started_at,
+            arguments={"product": product},
+            error=error,
         )
-        return (
-            f"Product slug {product!r} not found in catalog. "
-            f"Call list_products() to see all slugs. "
-            f"Examples: {sample}{more}."
-        )
-    return await _fetch(entry["llms_txt"])
 
 
 @mcp.tool()
@@ -286,13 +424,29 @@ async def doc_fetch_tool(
     Returns markdown mirror of the URL.
     Returns an error if the URL is on a disallowed domain.
     """
-    url = url.strip()
-    if not _url_allowed(url):
-        return (
-            f"Error: URL not on an allowed domain. "
-            f"Allowed: {_ALLOWED_DOMAINS_DISPLAY}"
+    started_at = time.perf_counter()
+    status = "success"
+    error = None
+    try:
+        url = url.strip()
+        if not _url_allowed(url):
+            return (
+                f"Error: URL not on an allowed domain. "
+                f"Allowed: {_ALLOWED_DOMAINS_DISPLAY}"
+            )
+        return await _fetch(url)
+    except Exception as e:
+        status = "error"
+        error = str(e)
+        raise
+    finally:
+        await _safe_record_tool_call(
+            tool="doc_fetch_tool",
+            status=status,
+            started_at=started_at,
+            arguments={"url": url},
+            error=error,
         )
-    return await _fetch(url)
 
 
 # Export the underlying low-level Server for main.py / stdio.py

--- a/juspay_mcp/analytics/__init__.py
+++ b/juspay_mcp/analytics/__init__.py
@@ -1,0 +1,23 @@
+"""Client-side analytics for the juspay-mcp docs + dashboard servers.
+
+Events are emitted best-effort (fire-and-forget) to the genius cli-analytics ingest
+endpoint; all session inference + storage lives server-side in genius. This package holds
+no DB credentials, schema, or session logic.
+"""
+
+from .context import (
+    AnalyticsRequestContext,
+    clear_current_context,
+    get_current_context,
+    set_current_context,
+)
+from .tracker import record_stage_status, record_tool_call
+
+__all__ = [
+    "AnalyticsRequestContext",
+    "clear_current_context",
+    "get_current_context",
+    "record_stage_status",
+    "record_tool_call",
+    "set_current_context",
+]

--- a/juspay_mcp/analytics/client.py
+++ b/juspay_mcp/analytics/client.py
@@ -1,0 +1,94 @@
+"""Ships analytics events to the genius cli-analytics ingest endpoint.
+
+Fire-and-forget: record_event schedules the POST as a background task and returns
+immediately, so a tool call never waits on analytics. Failures are logged and dropped;
+a 401/403 latches analytics off for the process lifetime. shutdown() flushes any pending
+posts and closes the shared client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from .config import load
+
+logger = logging.getLogger(__name__)
+
+_client: httpx.AsyncClient | None = None
+_pending: set[asyncio.Task] = set()
+_disabled_reason: str | None = None
+_disabled_logged = False
+
+
+def _get_client(timeout: float) -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(timeout=timeout)
+    return _client
+
+
+def _disable(reason: str) -> None:
+    global _disabled_reason, _disabled_logged
+    _disabled_reason = reason
+    if not _disabled_logged:
+        logger.warning("Analytics disabled: %s", reason)
+        _disabled_logged = True
+
+
+async def _post(url: str, token: str, timeout: float, payload: dict[str, Any]) -> None:
+    try:
+        resp = await _get_client(timeout).post(
+            url, json=payload, headers={"Authorization": f"Bearer {token}"}
+        )
+        if resp.status_code in (401, 403):
+            _disable("ingest token rejected — check CLI_ANALYTICS_INGEST_TOKEN")
+            return
+        resp.raise_for_status()
+    except Exception:
+        logger.debug("Analytics ingest failed", exc_info=True)  # best-effort: drop the event
+
+
+async def record_event(
+    *,
+    install_id: str,
+    event: dict[str, Any],
+    mid: str | None = None,
+    occurred_at: datetime | None = None,
+) -> None:
+    """Schedule a fire-and-forget POST of one event and return immediately.
+
+    Returns None — the session id is assigned server-side (genius) and not awaited here.
+    """
+    cfg = load()
+    if _disabled_reason is not None:
+        return None
+    if not (cfg.enabled and cfg.ingest_url and cfg.ingest_token):
+        return None
+
+    payload = {
+        "install_id": install_id,
+        "mid": mid,
+        "occurred_at": (occurred_at or datetime.now(timezone.utc)).isoformat(),
+        "event": event,
+    }
+    task = asyncio.create_task(
+        _post(cfg.ingest_url, cfg.ingest_token, cfg.http_timeout_seconds, payload)
+    )
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)
+    return None
+
+
+async def shutdown() -> None:
+    """Flush pending posts and close the shared client (called from main.py's lifespan)."""
+    if _pending:
+        await asyncio.gather(*list(_pending), return_exceptions=True)
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None

--- a/juspay_mcp/analytics/config.py
+++ b/juspay_mcp/analytics/config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    return int(raw)
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def is_local_development() -> bool:
+    raw = os.getenv("DEPLOYMENT_ENV") or ""
+    return raw.strip().lower() == "local"
+
+
+@dataclass(frozen=True)
+class AnalyticsConfig:
+    enabled: bool
+    ingest_url: str | None
+    ingest_token: str | None
+    event_max_bytes: int
+    http_timeout_seconds: float
+
+
+def load() -> AnalyticsConfig:
+    ingest_url = os.getenv("CLI_ANALYTICS_INGEST_URL") or None
+    ingest_token = os.getenv("CLI_ANALYTICS_INGEST_TOKEN") or None
+    # Default on only when we have somewhere to send + a token to send with.
+    enabled = _env_bool("CLI_ANALYTICS_ENABLED", bool(ingest_url and ingest_token))
+    return AnalyticsConfig(
+        enabled=enabled,
+        ingest_url=ingest_url,
+        ingest_token=ingest_token,
+        event_max_bytes=_env_int("CLI_ANALYTICS_EVENT_MAX_BYTES", 32 * 1024),
+        http_timeout_seconds=_env_float("CLI_ANALYTICS_HTTP_TIMEOUT_SECONDS", 2.0),
+    )

--- a/juspay_mcp/analytics/context.py
+++ b/juspay_mcp/analytics/context.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from starlette.requests import Request
+
+
+INSTALL_ID_HEADER = "x-juspay-install-id"
+SESSION_ID_HEADER = "x-juspay-session-id"
+
+
+@dataclass(frozen=True)
+class AnalyticsRequestContext:
+    mcp: str
+    install_id: str | None
+    mid: str | None
+    session_id: str | None = None
+
+
+_current: ContextVar[AnalyticsRequestContext | None] = ContextVar(
+    "juspay_mcp_analytics_context",
+    default=None,
+)
+
+
+def _empty_to_none(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _mid_from_request(request: Request) -> str | None:
+    oauth_context = getattr(request.state, "oauth_context", None)
+    if oauth_context and getattr(oauth_context, "user_info", None):
+        return _empty_to_none(getattr(oauth_context.user_info, "merchant_id", None))
+
+    creds = getattr(request.state, "juspay_credentials", None)
+    if isinstance(creds, dict):
+        return _empty_to_none(creds.get("merchant_id"))
+    return None
+
+
+def from_request(request: Request, mcp: str) -> AnalyticsRequestContext:
+    return AnalyticsRequestContext(
+        mcp=mcp,
+        install_id=_empty_to_none(request.headers.get(INSTALL_ID_HEADER)),
+        mid=_mid_from_request(request),
+        session_id=_empty_to_none(request.headers.get(SESSION_ID_HEADER)),
+    )
+
+
+def set_current_context(ctx: AnalyticsRequestContext | None) -> None:
+    _current.set(ctx)
+
+
+def get_current_context() -> AnalyticsRequestContext | None:
+    return _current.get()
+
+
+def clear_current_context() -> None:
+    _current.set(None)

--- a/juspay_mcp/analytics/identity.py
+++ b/juspay_mcp/analytics/identity.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+import time
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_AUTHORIZE_QUERY = "resource={%22COMMON%22%20%3A%20%22R%22}"
+_CACHE_TTL_SECONDS = 300
+_mid_cache: dict[str, tuple[str | None, float]] = {}
+
+
+def _normalize_mid(value: object) -> str | None:
+    if value is None:
+        return None
+    mid = str(value).strip()
+    return mid or None
+
+
+def extract_mid(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+
+    for key in ("merchantId", "merchant_id", "mid"):
+        mid = _normalize_mid(value.get(key))
+        if mid:
+            return mid
+
+    for key in ("merchant", "data", "user", "session"):
+        nested = value.get(key)
+        if isinstance(nested, dict):
+            mid = extract_mid(nested)
+            if mid:
+                return mid
+    return None
+
+
+async def resolve_mid_from_dashboard_token(
+    *,
+    token: str | None,
+    portal_base_url: str,
+) -> str | None:
+    if not token:
+        return None
+
+    now = time.time()
+    cached = _mid_cache.get(token)
+    if cached is not None:
+        mid, expires_at = cached
+        if expires_at > now:
+            return mid
+        _mid_cache.pop(token, None)
+
+    url = f"{portal_base_url.rstrip('/')}/ec/v2/authorize?{_AUTHORIZE_QUERY}"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(url, headers={"Authorization": token})
+            resp.raise_for_status()
+            mid = extract_mid(resp.json())
+    except Exception as exc:
+        logger.warning("Analytics MID resolution failed: %s", exc)
+        mid = None
+
+    _mid_cache[token] = (mid, now + _CACHE_TTL_SECONDS)
+    return mid

--- a/juspay_mcp/analytics/redaction.py
+++ b/juspay_mcp/analytics/redaction.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "card",
+    "cookie",
+    "cvv",
+    "pan",
+    "password",
+    "secret",
+    "token",
+)
+
+REDACTED = "[REDACTED]"
+TRUNCATED = "[TRUNCATED]"
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(part in lowered for part in SENSITIVE_KEY_PARTS)
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            str_key = str(key)
+            redacted[str_key] = REDACTED if _is_sensitive_key(str_key) else redact(item)
+        return redacted
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [redact(item) for item in value]
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+
+    return value
+
+
+def fit_jsonb_payload(value: dict[str, Any], max_bytes: int) -> dict[str, Any]:
+    """Return a JSON-serializable payload no larger than max_bytes if possible."""
+    payload = redact(value)
+    encoded = json.dumps(payload, default=str, separators=(",", ":")).encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return payload
+
+    compact = dict(payload)
+    if "arguments" in compact:
+        compact["arguments"] = TRUNCATED
+    if "metadata" in compact:
+        compact["metadata"] = TRUNCATED
+
+    encoded = json.dumps(compact, default=str, separators=(",", ":")).encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return compact
+
+    return {
+        "type": compact.get("type", "unknown"),
+        "mcp": compact.get("mcp"),
+        "tool": compact.get("tool"),
+        "status": compact.get("status"),
+        "payload_truncated": True,
+    }

--- a/juspay_mcp/analytics/tracker.py
+++ b/juspay_mcp/analytics/tracker.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from .config import load
+from .context import get_current_context
+from .redaction import fit_jsonb_payload
+from .client import record_event
+
+logger = logging.getLogger(__name__)
+
+
+async def _emit(payload: dict[str, Any], *, mid: str | None = None) -> None:
+    ctx = get_current_context()
+    event_type = str(payload.get("type") or "unknown")
+    tool = payload.get("tool")
+    if ctx is None:
+        logger.debug("Analytics skipped: no request context type=%s tool=%s", event_type, tool)
+        return
+    if not ctx.install_id:
+        logger.info("Analytics skipped: missing install_id mcp=%s type=%s tool=%s", ctx.mcp, event_type, tool)
+        return
+
+    cfg = load()
+    if not cfg.enabled:
+        logger.debug("Analytics skipped: disabled mcp=%s type=%s tool=%s", ctx.mcp, event_type, tool)
+        return
+
+    event = {
+        "mcp": ctx.mcp,
+        **payload,
+    }
+    event = fit_jsonb_payload(event, cfg.event_max_bytes)
+    event_mid = mid or ctx.mid
+    # Fire-and-forget: record_event schedules the POST and returns None immediately.
+    await record_event(install_id=ctx.install_id, mid=event_mid, event=event)
+
+
+async def record_stage_status(
+    *,
+    phase: str,
+    status: str,
+    product: str | None = None,
+    platform: str | None = None,
+    framework: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    await _emit(
+        {
+            "type": "stage_status",
+            "tool": "juspay_track_integration_stage",
+            "phase": phase,
+            "status": status,
+            "product": product,
+            "platform": platform,
+            "framework": framework,
+            "metadata": metadata or {},
+        }
+    )
+
+
+async def record_tool_call(
+    *,
+    tool: str,
+    status: str,
+    started_at: float,
+    arguments: dict[str, Any] | None = None,
+    error: str | None = None,
+    mid: str | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        "type": "tool_call",
+        "tool": tool,
+        "status": status,
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "arguments": arguments or {},
+    }
+    if error:
+        payload["error"] = error
+    await _emit(payload, mid=mid)

--- a/juspay_mcp/main.py
+++ b/juspay_mcp/main.py
@@ -31,6 +31,12 @@ from juspay_mcp.auth.middleware import BearerAuthMiddleware
 from juspay_mcp.auth.portal_client import PortalClient
 from juspay_mcp.auth.routes import build_routes as build_oauth_routes
 from juspay_mcp.auth.state_store import MemoryStateStore
+from juspay_mcp.analytics.context import (
+    clear_current_context as clear_analytics_context,
+    from_request as analytics_context_from_request,
+    set_current_context as set_analytics_context,
+)
+from juspay_mcp.analytics.client import shutdown as shutdown_analytics
 
 # Determine which MCP app to use based on JUSPAY_MCP_TYPE
 JUSPAY_MCP_TYPE = os.getenv("JUSPAY_MCP_TYPE", "").upper()
@@ -189,36 +195,42 @@ def main(host: str, port: int, mode: str):
                 f"New SSE connection from: {request.client} - {request.method} {request.url.path}"
             )
 
-            if active_app_key == "dashboard":
-                from juspay_dashboard_mcp.tools import set_juspay_request_credentials
-                juspay_creds = getattr(request.state, "juspay_credentials", None)
-                set_juspay_request_credentials(juspay_creds)
-            elif active_app_key == "ai_studio":
-                from juspay_ai_studio_mcp.tools import set_juspay_request_credentials
-                juspay_creds = getattr(request.state, "juspay_credentials", None)
-                set_juspay_request_credentials(juspay_creds)
-            elif active_app_key == "default":
-                from juspay_mcp.tools import set_juspay_request_credentials
-                juspay_creds = getattr(request.state, "juspay_credentials", None)
-                set_juspay_request_credentials(juspay_creds)
-            # docs: no credentials needed
+            if JUSPAY_MCP_TYPE == "DASHBOARD" and active_app_key in ("dashboard", "docs"):
+                set_analytics_context(analytics_context_from_request(request, active_app_key))
 
-            async with transport.connect_sse(
-                request.scope, request.receive, request._send
-            ) as streams:
-                logging.info(f"MCP Session starting for {request.client}")
-                try:
-                    await active_app.run(
-                        streams[0],
-                        streams[1],
-                        active_app.create_initialization_options(),
-                    )
-                except Exception as e:
-                    logging.error(
-                        f"Error during MCP session for {request.client}: {e}"
-                    )
-                finally:
-                    logging.info(f"MCP Session ended for {request.client}")
+            try:
+                if active_app_key == "dashboard":
+                    from juspay_dashboard_mcp.tools import set_juspay_request_credentials
+                    juspay_creds = getattr(request.state, "juspay_credentials", None)
+                    set_juspay_request_credentials(juspay_creds)
+                elif active_app_key == "ai_studio":
+                    from juspay_ai_studio_mcp.tools import set_juspay_request_credentials
+                    juspay_creds = getattr(request.state, "juspay_credentials", None)
+                    set_juspay_request_credentials(juspay_creds)
+                elif active_app_key == "default":
+                    from juspay_mcp.tools import set_juspay_request_credentials
+                    juspay_creds = getattr(request.state, "juspay_credentials", None)
+                    set_juspay_request_credentials(juspay_creds)
+                # docs: no credentials needed
+
+                async with transport.connect_sse(
+                    request.scope, request.receive, request._send
+                ) as streams:
+                    logging.info(f"MCP Session starting for {request.client}")
+                    try:
+                        await active_app.run(
+                            streams[0],
+                            streams[1],
+                            active_app.create_initialization_options(),
+                        )
+                    except Exception as e:
+                        logging.error(
+                            f"Error during MCP session for {request.client}: {e}"
+                        )
+                    finally:
+                        logging.info(f"MCP Session ended for {request.client}")
+            finally:
+                clear_analytics_context()
 
             return _AlreadySentResponse()
 
@@ -244,22 +256,28 @@ def main(host: str, port: int, mode: str):
                 f"New StreamableHTTP request from: {request.client} - {request.method} {request.url.path}"
             )
 
-            if active_app_key == "dashboard":
-                from juspay_dashboard_mcp.tools import set_juspay_request_credentials
-                juspay_creds = getattr(request.state, "juspay_credentials", None)
-                set_juspay_request_credentials(juspay_creds)
-            elif active_app_key == "ai_studio":
-                from juspay_ai_studio_mcp.tools import set_juspay_request_credentials
-                juspay_creds = getattr(request.state, "juspay_credentials", None)
-                set_juspay_request_credentials(juspay_creds)
-            elif active_app_key == "default":
-                from juspay_mcp.tools import set_juspay_request_credentials
-                juspay_creds = getattr(request.state, "juspay_credentials", None)
-                set_juspay_request_credentials(juspay_creds)
-            # docs: no credentials needed
+            if JUSPAY_MCP_TYPE == "DASHBOARD" and active_app_key in ("dashboard", "docs"):
+                set_analytics_context(analytics_context_from_request(request, active_app_key))
 
-            # session_manager writes the full HTTP response directly to send
-            await session_manager.handle_request(request.scope, request.receive, request._send)
+            try:
+                if active_app_key == "dashboard":
+                    from juspay_dashboard_mcp.tools import set_juspay_request_credentials
+                    juspay_creds = getattr(request.state, "juspay_credentials", None)
+                    set_juspay_request_credentials(juspay_creds)
+                elif active_app_key == "ai_studio":
+                    from juspay_ai_studio_mcp.tools import set_juspay_request_credentials
+                    juspay_creds = getattr(request.state, "juspay_credentials", None)
+                    set_juspay_request_credentials(juspay_creds)
+                elif active_app_key == "default":
+                    from juspay_mcp.tools import set_juspay_request_credentials
+                    juspay_creds = getattr(request.state, "juspay_credentials", None)
+                    set_juspay_request_credentials(juspay_creds)
+                # docs: no credentials needed
+
+                # session_manager writes the full HTTP response directly to send
+                await session_manager.handle_request(request.scope, request.receive, request._send)
+            finally:
+                clear_analytics_context()
             return _AlreadySentResponse()
 
         return handle_streamable_http, session_manager
@@ -370,13 +388,16 @@ def main(host: str, port: int, mode: str):
         @contextlib.asynccontextmanager
         async def lifespan(app):
             """Application lifespan context manager for multiple MCP apps."""
-            async with contextlib.AsyncExitStack() as stack:
-                await stack.enter_async_context(dashboard_session_mgr.run())
-                logger.info("Dashboard StreamableHTTP session manager started")
-                await stack.enter_async_context(docs_session_mgr.run())
-                logger.info("Docs StreamableHTTP session manager started")
-                logger.info("All StreamableHTTP session managers started successfully")
-                yield
+            try:
+                async with contextlib.AsyncExitStack() as stack:
+                    await stack.enter_async_context(dashboard_session_mgr.run())
+                    logger.info("Dashboard StreamableHTTP session manager started")
+                    await stack.enter_async_context(docs_session_mgr.run())
+                    logger.info("Docs StreamableHTTP session manager started")
+                    logger.info("All StreamableHTTP session managers started successfully")
+                    yield
+            finally:
+                await shutdown_analytics()
             logger.info("StreamableHTTP session managers stopped")
     elif JUSPAY_MCP_TYPE in AI_STUDIO_MCP_TYPES:
         ai_studio_sse_handler = make_sse_handler("ai_studio", sse_transport_handler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["juspay_mcp", "juspay_mcp.api", "juspay_mcp.api_schema", "juspay_mcp.auth", "juspay_dashboard_mcp", "juspay_dashboard_mcp.api", "juspay_dashboard_mcp.api_schema", "juspay_docs_mcp", "juspay_ai_studio_mcp", "juspay_ai_studio_mcp.api", "juspay_ai_studio_mcp.api_schema"]
+packages = ["juspay_mcp", "juspay_mcp.api", "juspay_mcp.api_schema", "juspay_mcp.auth", "juspay_mcp.analytics", "juspay_dashboard_mcp", "juspay_dashboard_mcp.api", "juspay_dashboard_mcp.api_schema", "juspay_docs_mcp", "juspay_ai_studio_mcp", "juspay_ai_studio_mcp.api", "juspay_ai_studio_mcp.api_schema"]
 
 [tool.setuptools.package-data]
 juspay_docs_mcp = ["transcripts.json", "dataset/*.json"]


### PR DESCRIPTION
Wrap docs + dashboard MCP tools to emit best-effort, fire-and-forget events to the genius cli-analytics ingest endpoint, plus a juspay_track_integration_stage tool for funnel milestones. Thin + public-safe: no DB credentials, schema, or session logic here (all backend logic lives in juspay-genius). Off by default without CLI_ANALYTICS_* env