### PR TITLE
Feature/preflight session

### DIFF
--- a/juspay_mcp/api/session_preflight.py
+++ b/juspay_mcp/api/session_preflight.py
@@ -1,0 +1,131 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+
+from juspay_mcp.api_schema.session import JuspaySessionPayload
+from juspay_mcp.api_schema.session_preflight import JuspaySessionPreflightPayload
+
+DEFAULT_GATEWAY = "DEFAULT"
+
+# Extra mandatory params a configured gateway needs on top of whatever the
+# session create API itself requires. Keyed by gateway name (upper-cased).
+# `amount` and `return_url` are intentionally absent here — they are already
+# required by JuspaySessionPayload and are picked up from the session schema.
+GATEWAY_REQUIREMENTS = {
+    DEFAULT_GATEWAY: [
+        "currency",
+    ],
+}
+
+# Field descriptions, so the caller is told what to go collect.
+_FIELD_DESCRIPTIONS = {
+    name: prop.get("description", "")
+    for name, prop in JuspaySessionPreflightPayload.model_json_schema()
+    .get("properties", {})
+    .items()
+}
+
+
+def _session_required_fields() -> list[str]:
+    """Required fields of the session create API, read off its live schema so
+    this check never drifts from JuspaySessionPayload."""
+    return list(JuspaySessionPayload.model_json_schema().get("required", []))
+
+
+def _is_absent(value) -> bool:
+    """A present-but-blank value is as useless to the gateway as an absent one."""
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+def _requirements(gateway: str) -> list[tuple[str, str]]:
+    """Merged (field, source) requirements, session fields first, deduped."""
+    merged: list[tuple[str, str]] = []
+    seen = set()
+    for field in _session_required_fields():
+        if field not in seen:
+            seen.add(field)
+            merged.append((field, "session_schema"))
+    for field in GATEWAY_REQUIREMENTS[gateway]:
+        if field not in seen:
+            seen.add(field)
+            merged.append((field, "gateway"))
+    return merged
+
+
+def _next_action(missing: list[dict]) -> str:
+    """The instruction handed back to the calling agent. Missing params must be
+    collected from the user — never guessed, defaulted or invented — so this
+    spells that out rather than relying on the tool description alone."""
+    if not missing:
+        return (
+            "All mandatory params are present. You may now call session_api_juspay "
+            "with this payload."
+        )
+
+    fields = ", ".join(entry["field"] for entry in missing)
+    return (
+        "Do NOT call session_api_juspay yet, and do NOT guess, invent, default or "
+        "use placeholder values for the missing params. Ask the user to supply "
+        f"these {len(missing)} param(s) directly: {fields}. Use each param's "
+        "`description` to phrase the request. Once the user has provided them, "
+        "call session_preflight_check_juspay again to confirm nothing is "
+        "outstanding before creating the session."
+    )
+
+
+async def session_preflight_check_juspay(payload: dict) -> dict:
+    """
+    Reports which mandatory params are still missing before a Juspay session
+    can be created and carried through to a completed payment.
+
+    Purely local — makes no network call. Combines the required fields of the
+    session create API with the extra params the configured gateway demands,
+    then reports which of them the given payload is missing.
+
+    Args:
+        payload (dict): A partial (or empty) session payload, optionally with a
+                        `gateway` key naming the configured gateway.
+
+    When anything is missing, the returned `next_action` instructs the calling
+    agent to collect those params from the user rather than proceeding.
+
+    Returns:
+        dict: {ready, gateway, gateway_recognised, next_action, missing, satisfied}
+    """
+    payload = payload or {}
+
+    requested_gateway = payload.get("gateway") or DEFAULT_GATEWAY
+    gateway = str(requested_gateway).upper()
+    gateway_recognised = gateway in GATEWAY_REQUIREMENTS
+    if not gateway_recognised:
+        gateway = DEFAULT_GATEWAY
+
+    missing = []
+    satisfied = []
+
+    for field, source in _requirements(gateway):
+        if _is_absent(payload.get(field)):
+            missing.append(
+                {
+                    "field": field,
+                    "description": _FIELD_DESCRIPTIONS.get(field, ""),
+                    "source": source,
+                }
+            )
+        else:
+            satisfied.append(field)
+
+    return {
+        "ready": not missing,
+        "gateway": gateway,
+        "gateway_recognised": gateway_recognised,
+        "next_action": _next_action(missing),
+        "missing": missing,
+        "satisfied": satisfied,
+    }

--- a/juspay_mcp/api_schema/session_preflight.py
+++ b/juspay_mcp/api_schema/session_preflight.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Juspay
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
+
+from pydantic import BaseModel, Field
+from typing import Optional, Literal
+
+
+class JuspaySessionPreflightPayload(BaseModel):
+    """Payload for the session preflight check.
+
+    Every field is deliberately Optional. This tool exists to report which
+    mandatory fields are *absent*, so it must be callable with a partial (even
+    empty) payload — the generic required-field guard in `tools.py` would
+    otherwise reject the call before the check could run.
+    """
+
+    gateway: Optional[str] = Field(
+        None,
+        description=(
+            "Name of the configured payment gateway whose extra mandatory "
+            "requirements should be checked (e.g., 'RAZORPAY'). "
+            "Defaults to 'DEFAULT' when omitted or unrecognised."
+        ),
+    )
+
+    # --- Fields mirrored from JuspaySessionPayload ---
+    order_id: Optional[str] = Field(None, description="Unique Identifier for the order (Max 21 Alphanumeric).")
+    amount: Optional[str] = Field(None, description="Amount customer has to pay (e.g., '1.00').")
+    customer_id: Optional[str] = Field(None, description="Unique merchant identifier for the customer.")
+    customer_email: Optional[str] = Field(None, description="Customer's email address.")
+    customer_phone: Optional[str] = Field(None, description="Customer's mobile number.")
+    payment_page_client_id: Optional[str] = Field(None, description="Unique merchant identifier provided by Juspay.")
+    action: Optional[Literal["paymentPage", "paymentManagement"]] = Field(
+        None,
+        description="Action to be performed, e.g., 'paymentPage'."
+    )
+    return_url: Optional[str] = Field(None, description="URL for redirection post payment.")
+
+    # --- Extra fields required to carry the payment through to completion ---
+    currency: Optional[str] = Field(None, description="Currency code (e.g., 'INR').")
+
+    class Config:
+        extra = "allow"

--- a/juspay_mcp/response_schema.py
+++ b/juspay_mcp/response_schema.py
@@ -4,6 +4,51 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.txt
 
+session_preflight_response_schema = {
+    "type": "object",
+    "properties": {
+        "ready": {
+            "type": "boolean",
+            "description": "True when nothing is missing and the session can be created."
+        },
+        "gateway": {
+            "type": "string",
+            "description": "The gateway whose requirements were applied ('DEFAULT' if the requested one was unknown)."
+        },
+        "gateway_recognised": {
+            "type": "boolean",
+            "description": "False when the requested gateway had no configured requirements and DEFAULT was used instead."
+        },
+        "next_action": {
+            "type": "string",
+            "description": "Instruction for the calling agent. When params are missing it directs the agent to ask the user for them rather than guessing or using placeholders, and to re-run this check before creating the session."
+        },
+        "missing": {
+            "type": "array",
+            "description": "Mandatory params that are absent (or blank) and must be collected from the user before proceeding.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "field": {"type": "string", "description": "Name of the missing param."},
+                    "description": {"type": "string", "description": "What the param is, to help collect it."},
+                    "source": {
+                        "type": "string",
+                        "description": "'session_schema' if the session create call itself will fail without it; 'gateway' if the session succeeds but the payment cannot complete.",
+                        "enum": ["session_schema", "gateway"]
+                    }
+                },
+                "required": ["field", "source"]
+            }
+        },
+        "satisfied": {
+            "type": "array",
+            "description": "Mandatory params already supplied.",
+            "items": {"type": "string"}
+        }
+    },
+    "required": ["ready", "gateway", "next_action", "missing", "satisfied"]
+}
+
 session_response_schema = {
     "type": "object",
     "properties": {

--- a/juspay_mcp/tools.py
+++ b/juspay_mcp/tools.py
@@ -32,6 +32,24 @@ def get_juspay_request_credentials():
 
 AVAILABLE_TOOLS = [
     util.make_api_config(
+        name="session_preflight_check_juspay",
+        description="""ALWAYS call this before `session_api_juspay`. Reports which mandatory params are still missing for the configured payment gateway.
+
+Key features:
+- Accepts a partial (or empty) session payload — nothing is required, so it can be called as soon as you start gathering details.
+- Combines the required fields of the session create API with the extra params the configured gateway demands (e.g. currency).
+- Returns `missing` (absent or blank params, each with a description to help collect it) and `satisfied`.
+- Each entry carries a `source`: 'session_schema' means the session create call itself will fail without it; 'gateway' means the session succeeds but the payment cannot complete.
+- Returns a `next_action` instruction telling you what to do next — follow it.
+- Accepts an optional `gateway` name; falls back to DEFAULT requirements (and flags `gateway_recognised: false`) when the name is unknown.
+- Makes no network call and creates nothing — it is safe to call repeatedly while collecting details.
+
+Use this tool to find out what to ask the user for before attempting a payment session. Anything reported in `missing` must be obtained from the user — never guess, invent, default or use placeholder values for it. Ask the user for the missing params, then call this tool again. Only call `session_api_juspay` once this returns `ready: true`.""",
+        model=api_schema.session_preflight.JuspaySessionPreflightPayload,
+        handler=session_preflight.session_preflight_check_juspay,
+        response_schema=response_schema.session_preflight_response_schema,
+    ),
+    util.make_api_config(
         name="session_api_juspay",
         description="Creates a new Juspay session for a given order.",
         model=api_schema.session.JuspaySessionPayload,

--- a/tools_test/smoke_session_preflight.py
+++ b/tools_test/smoke_session_preflight.py
@@ -1,0 +1,152 @@
+"""Verify the session preflight check reports missing mandatory params correctly:
+an empty payload flags everything, a complete payload is ready, blank values count
+as missing, and an unknown gateway falls back to DEFAULT. Also asserts the tool is
+registered and callable with a partial payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from juspay_mcp.api.session_preflight import (
+    GATEWAY_REQUIREMENTS,
+    session_preflight_check_juspay,
+)
+from juspay_mcp.api_schema.session import JuspaySessionPayload
+from juspay_mcp.api_schema.session_preflight import JuspaySessionPreflightPayload
+from juspay_mcp.tools import AVAILABLE_TOOLS
+
+failures = []
+
+
+def check(condition, message):
+    if condition:
+        print(f"[OK] {message}")
+    else:
+        print(f"[FAIL] {message}")
+        failures.append(message)
+
+
+def run(payload):
+    return asyncio.run(session_preflight_check_juspay(payload))
+
+
+SESSION_REQUIRED = list(JuspaySessionPayload.model_json_schema()["required"])
+GATEWAY_EXTRAS = GATEWAY_REQUIREMENTS["DEFAULT"]
+
+COMPLETE = {
+    "order_id": "ord_1",
+    "amount": "1.00",
+    "customer_id": "cust_1",
+    "customer_email": "a@b.com",
+    "customer_phone": "9999999999",
+    "payment_page_client_id": "client_1",
+    "action": "paymentPage",
+    "return_url": "https://example.com/return",
+    "currency": "INR",
+}
+
+# --- The tool must be registered, and its schema must require nothing ---
+entry = next((t for t in AVAILABLE_TOOLS if t["name"] == "session_preflight_check_juspay"), None)
+check(entry is not None, "session_preflight_check_juspay is registered in AVAILABLE_TOOLS")
+if entry is not None:
+    check(
+        not entry["schema"].get("required"),
+        "preflight schema declares no required fields (so partial payloads reach the handler)",
+    )
+
+# --- Empty payload: everything is missing ---
+result = run({})
+check(result["ready"] is False, "empty payload -> ready is False")
+missing_fields = {m["field"] for m in result["missing"]}
+check(
+    missing_fields == set(SESSION_REQUIRED) | set(GATEWAY_EXTRAS),
+    "empty payload -> every session-required and gateway-extra field is missing",
+)
+check(result["satisfied"] == [], "empty payload -> nothing satisfied")
+check(
+    {m["field"] for m in result["missing"] if m["source"] == "gateway"} == set(GATEWAY_EXTRAS),
+    "empty payload -> gateway extras are tagged source 'gateway'",
+)
+check(
+    all(m["description"] for m in result["missing"]),
+    "every missing entry carries a description",
+)
+
+# --- next_action must direct the agent to collect missing params from the user ---
+action = result["next_action"]
+check("ask the user" in action.lower(), "missing params -> next_action tells the agent to ask the user")
+check(
+    all(field in action for field in missing_fields),
+    "missing params -> next_action names every missing field",
+)
+check(
+    "do not guess" in action.lower() and "placeholder" in action.lower(),
+    "missing params -> next_action forbids guessing or placeholder values",
+)
+check(
+    "session_api_juspay" in action,
+    "missing params -> next_action names the tool that must not be called yet",
+)
+
+# --- Complete payload: ready ---
+result = run(dict(COMPLETE))
+check(result["ready"] is True, "complete payload -> ready is True")
+check(result["missing"] == [], "complete payload -> nothing missing")
+check(
+    set(result["satisfied"]) == set(SESSION_REQUIRED) | set(GATEWAY_EXTRAS),
+    "complete payload -> all mandatory params satisfied",
+)
+check(
+    "ask the user" not in result["next_action"].lower()
+    and "session_api_juspay" in result["next_action"],
+    "complete payload -> next_action clears the agent to call session_api_juspay",
+)
+
+# --- A single missing param still yields a directive naming just that param ---
+result = run({k: v for k, v in COMPLETE.items() if k != "currency"})
+action = result["next_action"]
+check("currency" in action, "one missing param -> next_action names it")
+check(
+    "order_id" not in action and "customer_email" not in action,
+    "one missing param -> next_action does not name satisfied params",
+)
+
+# --- Dropped params must stay dropped ---
+DROPPED = ["confirm", "card_number", "card_exp_month", "card_exp_year"]
+empty_missing = {m["field"] for m in run({})["missing"]}
+schema_props = JuspaySessionPreflightPayload.model_json_schema()["properties"]
+for field in DROPPED:
+    check(field not in GATEWAY_EXTRAS, f"{field} is not in the gateway requirements")
+    check(field not in empty_missing, f"empty payload -> {field} is not reported as missing")
+    check(field not in schema_props, f"{field} is not in the preflight input schema")
+
+# --- Blank string counts as missing ---
+result = run(dict(COMPLETE, currency="   "))
+check(
+    "currency" in {m["field"] for m in result["missing"]},
+    "blank currency -> treated as missing",
+)
+
+# --- Unknown gateway falls back to DEFAULT ---
+result = run(dict(COMPLETE, gateway="NOT_A_REAL_GATEWAY"))
+check(result["gateway"] == "DEFAULT", "unknown gateway -> falls back to DEFAULT")
+check(result["gateway_recognised"] is False, "unknown gateway -> gateway_recognised is False")
+check(result["ready"] is True, "unknown gateway -> still evaluates against DEFAULT requirements")
+
+# --- Known gateway is recognised, case-insensitively ---
+result = run(dict(COMPLETE, gateway="default"))
+check(result["gateway_recognised"] is True, "lowercase known gateway -> recognised")
+
+# --- The pydantic model tolerates a partial payload ---
+try:
+    JuspaySessionPreflightPayload(**{"order_id": "ord_1"})
+    check(True, "JuspaySessionPreflightPayload accepts a partial payload")
+except Exception as exc:  # noqa: BLE001
+    check(False, f"JuspaySessionPreflightPayload rejected a partial payload: {exc}")
+
+if failures:
+    print(f"\n[FAIL] {len(failures)} check(s) failed")
+    sys.exit(1)
+print("\n[OK] session preflight check behaves as specified")


### PR DESCRIPTION
Adds session_preflight_check_juspay, a local no-network MCP tool that
takes a partial session payload and reports which mandatory params are
still missing, so an agent can collect them before calling
session_api_juspay instead of firing a call that fails downstream.

Requirements are the union of two sources, tagged per field so the
caller can tell them apart: the session create API's own required
fields, read live off JuspaySessionPayload's schema so the two never
drift, and per-gateway extras from GATEWAY_REQUIREMENTS (currently
currency), keyed by gateway name with a DEFAULT fallback.

Every input field is Optional by design — the required-field guard in
handle_tool_calls would otherwise reject the partial payloads this
tool exists to inspect.

The response carries a next_action directive instructing the agent to
ask the user for anything missing rather than guessing, inventing or
using placeholder values.